### PR TITLE
docs: add README files for directories

### DIFF
--- a/designacoes/README.md
+++ b/designacoes/README.md
@@ -1,0 +1,8 @@
+# Designações
+
+Contém os arquivos para gerenciar as designações de territórios.
+
+- `Designacao.js`: modelo de uma designação.
+- `designacoes.html`: página de listagem e edição.
+- `designacoes.js`: lógica de interface da tela.
+- `designacoesController.js`: controlador com as operações principais.

--- a/modulos/README.md
+++ b/modulos/README.md
@@ -1,0 +1,11 @@
+# Módulos
+
+Reúne funcionalidades centrais da aplicação.
+
+- `calendario.html` / `calendario.js`: módulo de calendário.
+- `db.js`: inicialização do banco de dados.
+- `main.js`: ponto de entrada dos módulos.
+- `mapa.html`: visualização de mapas.
+- `notificacoes.js`: envio de notificações.
+- `relatorios.js`: geração de relatórios.
+- `sugestoes.html` / `sugestoes.js`: sistema de sugestões.

--- a/saidas/README.md
+++ b/saidas/README.md
@@ -1,0 +1,8 @@
+# Saídas
+
+Arquivos relacionados ao gerenciamento dos grupos de campo.
+
+- `Saida.js`: modelo de uma saída.
+- `saidas.html`: interface dos grupos.
+- `saidas.js`: lógica de interação.
+- `saidasController.js`: controlador das operações de saídas.

--- a/territorios/README.md
+++ b/territorios/README.md
@@ -1,0 +1,8 @@
+# Territórios
+
+Diretório com os componentes de gerenciamento dos territórios.
+
+- `Territorio.js`: modelo de território.
+- `territorios.html`: interface de cadastro e edição.
+- `territorios.js`: lógica da tela.
+- `territoriosController.js`: controlador das operações de territórios.

--- a/utils/README.md
+++ b/utils/README.md
@@ -1,0 +1,6 @@
+# Utils
+
+Funções auxiliares reutilizadas por toda a aplicação.
+
+- `helpers.js`: utilitários genéricos.
+- `toast.js`: sistema de notificações visuais.


### PR DESCRIPTION
## Summary
- document designações module
- document central modules
- document saídas, territórios and utils directories

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bb35a010e083259a76410f1056800b