### PR TITLE
Fix preload syntax error and adjust feature list

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Built with Electron, Node.js, and SQLite, the app is fully offline and uses a lo
 - ✅ **Toasts & Sounds**: Instant feedback on user actions.
 - ✅ **Multi-language Support**: Switch between English and Portuguese.
 - ✅ **Audit & Error Logs**: Export system and error logs to PDF/CSV.
-- ✅ **Assignment History**: See which group handled each territory in the last 12 months. & Error Logs**: Export system and error logs to PDF/CSV.
+- ✅ **Assignment History**: See which group handled each territory in the last 12 months.
 - ✅ **Data Collection**: Trigger the territory scraper from the app and store the results.
 
 ## 🚀 Getting Started

--- a/preload.ts
+++ b/preload.ts
@@ -17,7 +17,7 @@ contextBridge.exposeInMainWorld('api', {
     listar:        () => ipcRenderer.invoke('territorios:listar'),
     adicionar:     (descricao:string) =>
                      ipcRenderer.invoke('territorios:adicionar', descricao),
-    editar:        (id:number, descricao:string,  ) =>
+    editar:        (id:number, descricao:string) =>
                      ipcRenderer.invoke('territorios:editar', id, descricao),
     deletar:       (id:number) => ipcRenderer.invoke('territorios:deletar', id),
     importarCSV:   (filePath:string) => ipcRenderer.invoke('territorios:importarCSV', filePath),


### PR DESCRIPTION
## Summary
- remove trailing comma in preload territories editor
- clarify feature list entry for assignment history

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx tsc --noEmit preload.ts` *(fails: Cannot find module 'electron')*
- `npm install --no-save @types/electron` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bf2b36dd448325b4652427e3d0a79a