### PR TITLE
feat: add sqlite adapter and basic db tests

### DIFF
--- a/electron/main/db/adapters.ts
+++ b/electron/main/db/adapters.ts
@@ -1,0 +1,86 @@
+import { DB, QueryParams, QueryResult, Tx } from './types';
+
+// sqlite3 não possui tipagens padrão no projeto, então usamos require
+// para obter a instância e ativar o modo verbose para melhor depuração.
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const sqlite3 = require('sqlite3').verbose();
+
+/**
+ * Interface estendida de `DB` que expõe a propriedade `lastID` em queries de
+ * escrita. Isso é útil para recuperar o identificador do último registro
+ * inserido em operações `INSERT`.
+ */
+export interface SQLiteDB extends DB {
+  query<Row = any>(
+    sql: string,
+    params?: QueryParams
+  ): Promise<QueryResult<Row> & { lastID?: number }>;
+}
+
+/**
+ * Cria um adaptador simplificado para o driver `sqlite3`, expondo a interface
+ * `DB` utilizada pelo restante da aplicação.
+ */
+export function sqliteAdapter(filename: string): SQLiteDB {
+  let database: any = null;
+
+  function connect() {
+    if (!database) {
+      database = new sqlite3.Database(filename);
+    }
+  }
+
+  function disconnect() {
+    if (database) {
+      database.close();
+      database = null;
+    }
+  }
+
+  function run(sql: string, params: QueryParams = []) {
+    return new Promise<{ changes: number; lastID?: number }>((resolve, reject) => {
+      database.run(sql, params as any, function (err: any) {
+        if (err) return reject(err);
+        resolve({ changes: this.changes, lastID: this.lastID });
+      });
+    });
+  }
+
+  function all(sql: string, params: QueryParams = []) {
+    return new Promise<any[]>((resolve, reject) => {
+      database.all(sql, params as any, (err: any, rows: any[]) => {
+        if (err) return reject(err);
+        resolve(rows || []);
+      });
+    });
+  }
+
+  async function query<Row = any>(
+    sql: string,
+    params: QueryParams = []
+  ): Promise<QueryResult<Row> & { lastID?: number }> {
+    if (!database) connect();
+    const isSelect = /^\s*select/i.test(sql);
+    if (isSelect) {
+      const rows = await all(sql, params);
+      return { rows, rowCount: rows.length };
+    }
+    const result = await run(sql, params);
+    return { rows: [], rowCount: result.changes, lastID: result.lastID };
+  }
+
+  async function transaction<T>(fn: (tx: Tx) => Promise<T>): Promise<T> {
+    await query('BEGIN');
+    try {
+      const res = await fn({ query });
+      await query('COMMIT');
+      return res;
+    } catch (err) {
+      await query('ROLLBACK');
+      throw err;
+    }
+  }
+
+  return { connect, disconnect, query, transaction };
+}
+

--- a/electron/main/db/index.ts
+++ b/electron/main/db/index.ts
@@ -1,6 +1,7 @@
-// Reexporta o módulo real do DB, mas em ESM/TS, e já tipa a interface.
-// Ajuste o caminho real do seu módulo DB aqui:
+// Reexporta o módulo consolidado do banco de dados (implementado em JS
+// convencional) garantindo tipagem para uso nos módulos em TypeScript.
 import * as RealDB from '../../../db';
+import type { DB } from './types';
 
 export type { DB, QueryResult, Tx } from './types';
 
@@ -17,4 +18,5 @@ ensure(RealDB as any, [
   // 'migrate', 'seed', ... se existirem
 ]);
 
-export const db = RealDB;
+// Exporta a instância já tipada para os demais módulos.
+export const db: DB = RealDB as unknown as DB;

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "main.js",
   "scripts": {
     "start": "electron .",
-    "dev": "electron ."
+    "dev": "electron .",
+    "test": "node --test tests/*.js"
   },
   "author": "",
   "license": "MIT",

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,19 @@
+process.env.DB_PATH = ':memory:';
+const test = require('node:test');
+const assert = require('node:assert');
+const db = require('../db');
+
+test('conecta e executa SELECT simples', async () => {
+  await db.connect();
+  const res = await db.query('SELECT 1 as value');
+  assert.strictEqual(res.rows[0].value, 1);
+  await db.disconnect();
+});
+
+test('insere e consulta registro', async () => {
+  await db.connect();
+  await db.query('INSERT INTO territorios (descricao) VALUES (?)', ['Teste']);
+  const { rows } = await db.query('SELECT descricao FROM territorios');
+  assert.ok(rows.some(r => r.descricao === 'Teste'));
+  await db.disconnect();
+});


### PR DESCRIPTION
## Summary
- implement a lightweight SQLite adapter matching the project DB interface
- expose the consolidated DB with typing and validation for expected methods
- add basic unit tests for connecting, inserting and querying the database

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bf35b39430832596d1aa404415e1ae