### PR TITLE
Add service tests and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: CI
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm test
+      - run: npm run build

--- a/services/saidas.js
+++ b/services/saidas.js
@@ -1,0 +1,80 @@
+const fs = require('fs');
+const path = require('path');
+const { dialog } = require('electron');
+const { all, run } = require('../db');
+
+async function listar() {
+  return await all('SELECT id, nome, dia_semana FROM saidas ORDER BY id');
+}
+
+async function adicionar(nome, dia_semana) {
+  if (!nome || !dia_semana) throw new Error('Campos obrigatórios ausentes');
+  await run('INSERT INTO saidas (nome, dia_semana) VALUES (?, ?)', [nome, dia_semana]);
+  return { ok: true };
+}
+
+async function editar(id, nome, dia_semana) {
+  if (!id || !nome || !dia_semana) throw new Error('Campos obrigatórios ausentes');
+  await run('UPDATE saidas SET nome = ?, dia_semana = ? WHERE id = ?', [nome, dia_semana, id]);
+  return { ok: true };
+}
+
+async function deletar(id) {
+  if (!id) throw new Error('ID inválido');
+  await run('DELETE FROM saidas WHERE id = ?', [id]);
+  return { ok: true };
+}
+
+async function importarCSV(filePath) {
+  if (!filePath) throw new Error('Caminho do arquivo CSV não informado');
+  const content = fs.readFileSync(filePath, 'utf8');
+  const lines = content.split(/\r?\n/).map(l => l.trim()).filter(Boolean);
+  if (lines.length === 0) return { imported: 0 };
+
+  let start = 0;
+  const header = lines[0].toLowerCase();
+  if (header.includes('nome') && header.includes('dia')) start = 1;
+
+  let imported = 0;
+  for (let i = start; i < lines.length; i++) {
+    const parts = lines[i].split(',');
+    if (parts.length < 2) continue;
+    const nome = parts[0].trim();
+    const dia = parts[1].trim();
+    if (!nome || !dia) continue;
+    await run('INSERT INTO saidas (nome, dia_semana) VALUES (?, ?)', [nome, dia]);
+    imported++;
+  }
+  return { imported };
+}
+
+async function exportarCSV() {
+  const rows = await listar();
+  const csv = ['nome,dia_semana', ...rows.map(r => `${escapeCSV(r.nome)},${escapeCSV(r.dia_semana)}`)].join('\n');
+  const res = await dialog.showSaveDialog({
+    title: 'Salvar Saídas (CSV)',
+    defaultPath: path.join(process.cwd(), 'saidas.csv'),
+    filters: [{ name: 'CSV', extensions: ['csv'] }],
+  });
+  if (res.canceled) return { canceled: true };
+  fs.writeFileSync(res.filePath, csv, 'utf8');
+  return { canceled: false, filePath: res.filePath };
+}
+
+function escapeCSV(value) {
+  const s = String(value ?? '');
+  if (s.includes(',') || s.includes('"') || s.includes('\n')) {
+    return '"' + s.replace(/"/g, '""') + '"';
+  }
+  return s;
+}
+
+module.exports = {
+  listar,
+  adicionar,
+  editar,
+  deletar,
+  importarCSV,
+  exportarCSV,
+};
+

--- a/tests/saidas.test.js
+++ b/tests/saidas.test.js
@@ -1,0 +1,25 @@
+process.env.DB_PATH = ':memory:';
+const test = require('node:test');
+const assert = require('node:assert');
+const { adicionar, listar, deletar } = require('../services/saidas');
+const db = require('../db');
+
+test('adiciona e lista saidas', async () => {
+  db.disconnect();
+  await adicionar('Teste', 'Segunda');
+  const rows = await listar();
+  assert.ok(rows.some(r => r.nome === 'Teste'));
+  db.disconnect();
+});
+
+test('deleta saida', async () => {
+  db.disconnect();
+  await adicionar('Apagar', 'Terça');
+  let rows = await listar();
+  const id = rows[0].id;
+  await deletar(id);
+  rows = await listar();
+  assert.ok(!rows.some(r => r.id === id));
+  db.disconnect();
+});
+


### PR DESCRIPTION
## Summary
- add JavaScript version of `saidas` service for testing
- cover `saidas` CRUD operations with unit tests
- run tests and build in GitHub Actions on each PR

## Testing
- `npm test` *(fails: npm not found)*
- `npm run build` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bf3dff63c483258a9f5a38a55fc4bc