### PR TITLE
Corrige carregamento de página inicial no Electron

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,12 @@ export default [
     files: ["**/*.{js,cjs,mjs}", "**/*.jsx"],
     languageOptions: {
       ecmaVersion: 'latest',
-      sourceType: 'module'
+      sourceType: 'module',
+      parserOptions: {
+        ecmaFeatures: {
+          jsx: true,
+        },
+      },
     },
     rules: {}
   }

--- a/main.js
+++ b/main.js
@@ -16,10 +16,13 @@ function createWindow() {
     },
   });
 
-  const appPath = app.getAppPath();
-  const rendererDist = path.join(appPath, 'renderer', 'dist', 'index.html');
-  const rendererHtml = path.join(appPath, 'renderer', 'index.html');
-  const legacyIndex = path.join(appPath, 'index.html');
+  // Determina o caminho base relativo a este arquivo. Usar __dirname evita
+  // problemas em ambientes onde app.getAppPath() aponta para um diretório que
+  // não contém os arquivos estáticos da interface.
+  const basePath = __dirname;
+  const rendererDist = path.join(basePath, 'renderer', 'dist', 'index.html');
+  const rendererHtml = path.join(basePath, 'renderer', 'index.html');
+  const legacyIndex = path.join(basePath, 'index.html');
 
   if (fs.existsSync(rendererDist)) {
     win.loadFile(rendererDist);


### PR DESCRIPTION
## Summary
- Usa `__dirname` para localizar arquivos de interface, evitando exibição da página genérica
- Habilita suporte a JSX no ESLint

## Testing
- `npm test`
- `npm run lint`
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68bf400ddc148325bbcff6ccf9af30d4