### PR TITLE
refactor: secure renderer with preload

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Assigna</title>
   <!-- Arquivo de estilos será adicionado futuramente -->
-  <!-- NodeIntegration está habilitado no BrowserWindow -->
+  <!-- APIs do Electron expostas via preload -->
 </head>
 <body>
   <h1>Assigna</h1>
@@ -51,23 +51,20 @@
   </div>
 
   <script>
-    // Mostra um pequeno status usando IPC já exposto em main.js
+    // Mostra um pequeno status usando a API exposta pelo preload
     (function () {
-      try {
-        const { ipcRenderer } = require('electron');
-        ipcRenderer.invoke('saidas:listar').then((lista) => {
-          const el = document.getElementById('saidas-info');
-          if (!el) return;
+      const el = document.getElementById('saidas-info');
+      if (!el) return;
+      if (window.api?.saidas?.listar) {
+        window.api.saidas.listar().then((lista) => {
           const total = Array.isArray(lista) ? lista.length : 0;
           el.textContent = `Total de saídas cadastradas: ${total}`;
         }).catch((err) => {
-          const el = document.getElementById('saidas-info');
-          if (el) el.textContent = 'Não foi possível carregar as saídas.';
+          el.textContent = 'Não foi possível carregar as saídas.';
           console.error(err);
         });
-      } catch (e) {
-        const el = document.getElementById('saidas-info');
-        if (el) el.textContent = 'IPC indisponível.';
+      } else {
+        el.textContent = 'IPC indisponível.';
       }
     })();
   </script>

--- a/main.js
+++ b/main.js
@@ -11,9 +11,10 @@ function createWindow() {
     width: 1200,
     height: 800,
     webPreferences: {
-      // Para protótipos é mais simples; considere usar preload + contextIsolation em produção
-      nodeIntegration: true,
-      contextIsolation: false,
+      // Usa preload com contextIsolation para expor APIs seguras ao renderer
+      nodeIntegration: false,
+      contextIsolation: true,
+      preload: path.join(__dirname, 'preload.js'),
     },
   });
 

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,3 @@
+require('./register-ts');
+require('./preload.ts');
+

--- a/renderer/index.html
+++ b/renderer/index.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Assigna</title>
   <!-- Arquivo de estilos será adicionado futuramente -->
-  <!-- NodeIntegration está habilitado no BrowserWindow -->
+  <!-- APIs do Electron expostas via preload -->
 </head>
 <body>
   <h1>Assigna</h1>
@@ -51,23 +51,20 @@
   </div>
 
   <script>
-    // Mostra um pequeno status usando IPC já exposto em main.js
+    // Mostra um pequeno status usando a API exposta pelo preload
     (function () {
-      try {
-        const { ipcRenderer } = require('electron');
-        ipcRenderer.invoke('saidas:listar').then((lista) => {
-          const el = document.getElementById('saidas-info');
-          if (!el) return;
+      const el = document.getElementById('saidas-info');
+      if (!el) return;
+      if (window.api?.saidas?.listar) {
+        window.api.saidas.listar().then((lista) => {
           const total = Array.isArray(lista) ? lista.length : 0;
           el.textContent = `Total de saídas cadastradas: ${total}`;
         }).catch((err) => {
-          const el = document.getElementById('saidas-info');
-          if (el) el.textContent = 'Não foi possível carregar as saídas.';
+          el.textContent = 'Não foi possível carregar as saídas.';
           console.error(err);
         });
-      } catch (e) {
-        const el = document.getElementById('saidas-info');
-        if (el) el.textContent = 'IPC indisponível.';
+      } else {
+        el.textContent = 'IPC indisponível.';
       }
     })();
   </script>


### PR DESCRIPTION
## Summary
- disable Node integration and enable context isolation with a preload script
- update HTML views to use IPC APIs exposed through the preload script

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68c1da3949f0832584b6629707f688ab