### PR TITLE
refactor: modularize preload APIs

### DIFF
--- a/preload.ts
+++ b/preload.ts
@@ -1,43 +1,16 @@
-import { contextBridge, ipcRenderer } from 'electron';
+import { contextBridge } from 'electron';
+
+import { designacoes } from './preload/designacoes';
+import { territorios } from './preload/territorios';
+import { saidas } from './preload/saidas';
+import { app } from './preload/app';
+import { pdf } from './preload/pdf';
 
 contextBridge.exposeInMainWorld('api', {
-  designacoes: {
-    listar: () => ipcRenderer.invoke('designacoes:listar'),
-    adicionar: (territorioId:number, saidaId:number, dataDesignacao:string, dataDevolucao:string) =>
-      ipcRenderer.invoke('designacoes:adicionar', territorioId, saidaId, dataDesignacao, dataDevolucao),
-    editar: (id:number, territorioId:number, saidaId:number, dataDesignacao:string, dataDevolucao:string) =>
-      ipcRenderer.invoke('designacoes:editar', id, territorioId, saidaId, dataDesignacao, dataDevolucao),
-    deletar: (id:number) => ipcRenderer.invoke('designacoes:deletar', id),
-    importarCSV: (filePath:string) => ipcRenderer.invoke('designacoes:importarCSV', filePath),
-    exportarCSV: () => ipcRenderer.invoke('designacoes:exportarCSV'),
-    historicoTerritorio: (id:number) => ipcRenderer.invoke('designacoes:historicoTerritorio', id),
-    historicoSaida: (id:number) => ipcRenderer.invoke('designacoes:historicoSaida', id),
-  },
-  territorios: {
-    listar:        () => ipcRenderer.invoke('territorios:listar'),
-    adicionar:     (descricao:string) =>
-                     ipcRenderer.invoke('territorios:adicionar', descricao),
-    editar:        (id:number, descricao:string) =>
-                     ipcRenderer.invoke('territorios:editar', id, descricao),
-    deletar:       (id:number) => ipcRenderer.invoke('territorios:deletar', id),
-    importarCSV:   (filePath:string) => ipcRenderer.invoke('territorios:importarCSV', filePath),
-    exportarCSV:   () => ipcRenderer.invoke('territorios:exportarCSV'),
-    carregarJSON:  (filePath:string) => ipcRenderer.invoke('territorios:carregarJSON', filePath),
-    agruparProximos: (raioKm?:number) => ipcRenderer.invoke('territorios:agruparProximos', raioKm ?? 1),
-  },
-  saidas: {
-      listar:        () => ipcRenderer.invoke('saidas:listar'),
-      adicionar:     (nome:string, dia:string) => ipcRenderer.invoke('saidas:adicionar', nome, dia),
-      editar:        (id:number, nome:string, dia:string) => ipcRenderer.invoke('saidas:editar', id, nome, dia),
-      deletar:       (id:number) => ipcRenderer.invoke('saidas:deletar', id),
-      importarCSV:   (filePath:string) => ipcRenderer.invoke('saidas:importarCSV', filePath),
-      exportarCSV:   () => ipcRenderer.invoke('saidas:exportarCSV'),
-    },
-  app: {
-    abrirDialogoCSV: () => ipcRenderer.invoke('app:abrirDialogoCSV'),
-  },
-  pdf: {
-    gerarRelatorio: (dados:any[], periodo:string) => ipcRenderer.invoke('pdf:gerarRelatorio', dados, periodo),
-    gerar: (titulo:string) => ipcRenderer.invoke('pdf:gerar', titulo),
-  }
+  designacoes,
+  territorios,
+  saidas,
+  app,
+  pdf,
 });
+

--- a/preload/app.ts
+++ b/preload/app.ts
@@ -1,0 +1,6 @@
+import { ipcRenderer } from 'electron';
+
+export const app = {
+  abrirDialogoCSV: () => ipcRenderer.invoke('app:abrirDialogoCSV'),
+};
+

--- a/preload/designacoes.ts
+++ b/preload/designacoes.ts
@@ -1,0 +1,42 @@
+import { ipcRenderer } from 'electron';
+
+export const designacoes = {
+  listar: () => ipcRenderer.invoke('designacoes:listar'),
+  adicionar: (
+    territorioId: number,
+    saidaId: number,
+    dataDesignacao: string,
+    dataDevolucao: string,
+  ) =>
+    ipcRenderer.invoke(
+      'designacoes:adicionar',
+      territorioId,
+      saidaId,
+      dataDesignacao,
+      dataDevolucao,
+    ),
+  editar: (
+    id: number,
+    territorioId: number,
+    saidaId: number,
+    dataDesignacao: string,
+    dataDevolucao: string,
+  ) =>
+    ipcRenderer.invoke(
+      'designacoes:editar',
+      id,
+      territorioId,
+      saidaId,
+      dataDesignacao,
+      dataDevolucao,
+    ),
+  deletar: (id: number) => ipcRenderer.invoke('designacoes:deletar', id),
+  importarCSV: (filePath: string) =>
+    ipcRenderer.invoke('designacoes:importarCSV', filePath),
+  exportarCSV: () => ipcRenderer.invoke('designacoes:exportarCSV'),
+  historicoTerritorio: (id: number) =>
+    ipcRenderer.invoke('designacoes:historicoTerritorio', id),
+  historicoSaida: (id: number) =>
+    ipcRenderer.invoke('designacoes:historicoSaida', id),
+};
+

--- a/preload/pdf.ts
+++ b/preload/pdf.ts
@@ -1,0 +1,8 @@
+import { ipcRenderer } from 'electron';
+
+export const pdf = {
+  gerarRelatorio: (dados: any[], periodo: string) =>
+    ipcRenderer.invoke('pdf:gerarRelatorio', dados, periodo),
+  gerar: (titulo: string) => ipcRenderer.invoke('pdf:gerar', titulo),
+};
+

--- a/preload/saidas.ts
+++ b/preload/saidas.ts
@@ -1,0 +1,14 @@
+import { ipcRenderer } from 'electron';
+
+export const saidas = {
+  listar: () => ipcRenderer.invoke('saidas:listar'),
+  adicionar: (nome: string, dia: string) =>
+    ipcRenderer.invoke('saidas:adicionar', nome, dia),
+  editar: (id: number, nome: string, dia: string) =>
+    ipcRenderer.invoke('saidas:editar', id, nome, dia),
+  deletar: (id: number) => ipcRenderer.invoke('saidas:deletar', id),
+  importarCSV: (filePath: string) =>
+    ipcRenderer.invoke('saidas:importarCSV', filePath),
+  exportarCSV: () => ipcRenderer.invoke('saidas:exportarCSV'),
+};
+

--- a/preload/territorios.ts
+++ b/preload/territorios.ts
@@ -1,0 +1,18 @@
+import { ipcRenderer } from 'electron';
+
+export const territorios = {
+  listar: () => ipcRenderer.invoke('territorios:listar'),
+  adicionar: (descricao: string) =>
+    ipcRenderer.invoke('territorios:adicionar', descricao),
+  editar: (id: number, descricao: string) =>
+    ipcRenderer.invoke('territorios:editar', id, descricao),
+  deletar: (id: number) => ipcRenderer.invoke('territorios:deletar', id),
+  importarCSV: (filePath: string) =>
+    ipcRenderer.invoke('territorios:importarCSV', filePath),
+  exportarCSV: () => ipcRenderer.invoke('territorios:exportarCSV'),
+  carregarJSON: (filePath: string) =>
+    ipcRenderer.invoke('territorios:carregarJSON', filePath),
+  agruparProximos: (raioKm?: number) =>
+    ipcRenderer.invoke('territorios:agruparProximos', raioKm ?? 1),
+};
+


### PR DESCRIPTION
## Summary
- split preload API into designacoes, territorios, saidas, app and pdf modules
- expose only required modules through contextBridge in preload.ts

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'typescript')*


------
https://chatgpt.com/codex/tasks/task_e_68c1dd53d9b88325b15b6589326f12d4