### PR TITLE
Add tests for error scenarios

### DIFF
--- a/services/saidas.ts
+++ b/services/saidas.ts
@@ -2,29 +2,50 @@ import fs from 'fs';
 import path from 'path';
 import { dialog } from 'electron';
 import db from '../db';
+import logger from '../logger';
 import type { Saida } from '../models';
 
 export async function listar(): Promise<Saida[]> {
-  const { rows } = await db.query<Saida>('SELECT id, nome, dia_semana FROM saidas ORDER BY id');
-  return rows;
+  try {
+    const { rows } = await db.query<Saida>('SELECT id, nome, dia_semana FROM saidas ORDER BY id');
+    return rows;
+  } catch (err) {
+    logger.error(`Erro ao listar saídas: ${(err as Error).message}`);
+    throw new Error('Erro ao listar saídas');
+  }
 }
 
 export async function adicionar(nome: string, dia_semana: string): Promise<{ ok: true }> {
   if (!nome || !dia_semana) throw new Error('Campos obrigatórios ausentes');
-  await db.query('INSERT INTO saidas (nome, dia_semana) VALUES (?, ?)', [nome, dia_semana]);
-  return { ok: true };
+  try {
+    await db.query('INSERT INTO saidas (nome, dia_semana) VALUES (?, ?)', [nome, dia_semana]);
+    return { ok: true };
+  } catch (err) {
+    logger.error(`Erro ao adicionar saída: ${(err as Error).message}`);
+    throw new Error('Erro ao adicionar saída');
+  }
 }
 
 export async function editar(id: number, nome: string, dia_semana: string): Promise<{ ok: true }> {
   if (!id || !nome || !dia_semana) throw new Error('Campos obrigatórios ausentes');
-  await db.query('UPDATE saidas SET nome = ?, dia_semana = ? WHERE id = ?', [nome, dia_semana, id]);
-  return { ok: true };
+  try {
+    await db.query('UPDATE saidas SET nome = ?, dia_semana = ? WHERE id = ?', [nome, dia_semana, id]);
+    return { ok: true };
+  } catch (err) {
+    logger.error(`Erro ao editar saída: ${(err as Error).message}`);
+    throw new Error('Erro ao editar saída');
+  }
 }
 
 export async function deletar(id: number): Promise<{ ok: true }> {
   if (!id) throw new Error('ID inválido');
-  await db.query('DELETE FROM saidas WHERE id = ?', [id]);
-  return { ok: true };
+  try {
+    await db.query('DELETE FROM saidas WHERE id = ?', [id]);
+    return { ok: true };
+  } catch (err) {
+    logger.error(`Erro ao deletar saída: ${(err as Error).message}`);
+    throw new Error('Erro ao deletar saída');
+  }
 }
 
 // Importa CSV simples com colunas: nome,dia_semana (com ou sem cabeçalho)

--- a/tests/saidas.test.js
+++ b/tests/saidas.test.js
@@ -2,7 +2,8 @@ process.env.DB_PATH = ':memory:';
 require('../register-ts');
 const test = require('node:test');
 const assert = require('node:assert');
-const { adicionar, listar, deletar } = require('../services/saidas.ts');
+const fs = require('fs');
+const { adicionar, listar, deletar, importarCSV } = require('../services/saidas.ts');
 const db = require('../db');
 
 test('adiciona e lista saidas', async () => {
@@ -22,5 +23,38 @@ test('deleta saida', async () => {
   rows = await listar();
   assert.ok(!rows.some(r => r.id === id));
   db.disconnect();
+});
+
+test('nao adiciona saida com campos obrigatorios ausentes', async () => {
+  await assert.rejects(() => adicionar('', ''), /Campos obrigatórios ausentes/);
+});
+
+test('importarCSV ignora linhas invalidas', async () => {
+  const originalReadFile = fs.promises.readFile;
+  fs.promises.readFile = async () => 'linha-invalida\noutra';
+  const res = await importarCSV('dummy.csv');
+  assert.strictEqual(res.imported, 0);
+  fs.promises.readFile = originalReadFile;
+});
+
+test('importarCSV falha em erro de leitura', async () => {
+  const originalReadFile = fs.promises.readFile;
+  fs.promises.readFile = async () => { throw new Error('EIO'); };
+  await assert.rejects(() => importarCSV('dummy.csv'), /EIO/);
+  fs.promises.readFile = originalReadFile;
+});
+
+test('adicionar trata erro do banco de dados', async () => {
+  const originalQuery = db.query;
+  db.query = async () => { throw new Error('falha'); };
+  await assert.rejects(() => adicionar('X', 'Y'), /Erro ao adicionar saída/);
+  db.query = originalQuery;
+});
+
+test('listar trata erro do banco de dados', async () => {
+  const originalQuery = db.query;
+  db.query = async () => { throw new Error('falha'); };
+  await assert.rejects(() => listar(), /Erro ao listar saídas/);
+  db.query = originalQuery;
 });
 


### PR DESCRIPTION
## Summary
- handle database errors in `saidas` service with logging
- cover invalid inputs, CSV parsing failures, and database errors in tests

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68c1e1f504c483259ed4949d47deb415