### PR TITLE
fix: handle path module import

### DIFF
--- a/db/index.ts
+++ b/db/index.ts
@@ -1,4 +1,4 @@
-import path from 'path';
+import * as path from 'path';
 import logger from '../logger';
 import { sqliteAdapter, SQLiteDB } from '../electron/main/db/adapters';
 import type { QueryParams, QueryResult, Tx } from '../electron/main/db/types';

--- a/services/saidas.ts
+++ b/services/saidas.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'fs';
+import * as path from 'path';
 import { dialog } from 'electron';
 import db from '../db';
 import logger from '../logger';


### PR DESCRIPTION
## Summary
- fix path module import to avoid undefined resolve error in db init
- adjust Saidas service to use star imports for Node built-ins

## Testing
- `npm run lint`
- `npm test` *(fails: ERR_TEST_FAILURE)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e3ae43ac8325b6cb4bfbb660411c