### PR TITLE
feat(renderer): enable router-based navigation

### DIFF
--- a/renderer/package-lock.json
+++ b/renderer/package-lock.json
@@ -15,7 +15,8 @@
         "lucide-react": "^0.542.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
-        "tailwind-merge": "^2.5.4"
+        "tailwind-merge": "^2.5.4",
+        "react-router-dom": "^6.23.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.3.3",

--- a/renderer/package.json
+++ b/renderer/package.json
@@ -16,6 +16,7 @@
     "lucide-react": "^0.542.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "^6.23.1",
     "tailwind-merge": "^2.5.4"
   },
   "devDependencies": {

--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Button } from '@/components/ui/button'
+import { Link, Routes, Route, Navigate, useLocation } from 'react-router-dom'
 
 const DesignacoesPage = React.lazy(() => import('@/components/DesignacoesPage'))
 const SaidasPage = React.lazy(() => import('@/components/SaidasPage'))
@@ -9,12 +10,12 @@ const ReportsPage = React.lazy(() => import('@/components/ReportsPage'))
 const SugestoesPage = React.lazy(() => import('@/components/SugestoesPage'))
 
 const TABS = [
-  { id: 'designacoes', label: 'Designações', Comp: DesignacoesPage },
-  { id: 'saidas', label: 'Saídas', Comp: SaidasPage },
-  { id: 'territorios', label: 'Territórios', Comp: TerritoriosPage },
-  { id: 'calendario', label: 'Calendário', Comp: CalendarPage },
-  { id: 'relatorios', label: 'Relatórios', Comp: ReportsPage },
-  { id: 'sugestoes', label: 'Sugestões', Comp: SugestoesPage },
+  { id: 'designacoes', label: 'Designações', path: '/designacoes', Comp: DesignacoesPage },
+  { id: 'saidas', label: 'Saídas', path: '/saidas', Comp: SaidasPage },
+  { id: 'territorios', label: 'Territórios', path: '/territorios', Comp: TerritoriosPage },
+  { id: 'calendario', label: 'Calendário', path: '/calendario', Comp: CalendarPage },
+  { id: 'relatorios', label: 'Relatórios', path: '/relatorios', Comp: ReportsPage },
+  { id: 'sugestoes', label: 'Sugestões', path: '/sugestoes', Comp: SugestoesPage },
 ]
 
 class ErrorBoundary extends React.Component {
@@ -39,8 +40,7 @@ class ErrorBoundary extends React.Component {
 }
 
 export default function App() {
-  const [tab, setTab] = React.useState('designacoes')
-  const Active = (TABS.find(t => t.id === tab)?.Comp) || DesignacoesPage
+  const location = useLocation()
 
   return (
     <div className="min-h-dvh bg-background text-foreground">
@@ -50,11 +50,11 @@ export default function App() {
           <nav className="flex gap-2 flex-wrap">
             {TABS.map(t => (
               <Button
+                asChild
                 key={t.id}
-                variant={t.id === tab ? 'default' : 'secondary'}
-                onClick={() => setTab(t.id)}
+                variant={location.pathname === t.path ? 'default' : 'secondary'}
               >
-                {t.label}
+                <Link to={t.path}>{t.label}</Link>
               </Button>
             ))}
           </nav>
@@ -64,7 +64,12 @@ export default function App() {
       <main className="max-w-6xl mx-auto px-4 py-6">
         <React.Suspense fallback={<div>Carregando...</div>}>
           <ErrorBoundary>
-            <Active />
+            <Routes>
+              {TABS.map(t => (
+                <Route key={t.id} path={t.path} element={<t.Comp />} />
+              ))}
+              <Route path="*" element={<Navigate to="/designacoes" replace />} />
+            </Routes>
           </ErrorBoundary>
         </React.Suspense>
       </main>

--- a/renderer/src/main.jsx
+++ b/renderer/src/main.jsx
@@ -4,12 +4,15 @@ import App from './App.jsx'
 import './index.css'
 import { ToastProvider } from './components/ui/toast'
 import { ConfirmProvider } from './components/ui/confirm-dialog'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ToastProvider>
       <ConfirmProvider>
-        <App />
+        <BrowserRouter>
+          <App />
+        </BrowserRouter>
       </ConfirmProvider>
     </ToastProvider>
   </React.StrictMode>


### PR DESCRIPTION
## Summary
- install react-router-dom
- switch App navigation from tabs to react-router with deep linking

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'typescript')*

------
https://chatgpt.com/codex/tasks/task_e_68c1ea87f1f88325896d153ec2e4e875