### PR TITLE
feat: improve tables accessibility and responsiveness

### DIFF
--- a/renderer/src/components/DesignacaoTable.tsx
+++ b/renderer/src/components/DesignacaoTable.tsx
@@ -11,7 +11,11 @@ type Props = {
 
 function th(label:string, key:string, sortKey:string, asc:boolean, ordenarPor:(k:any)=>void) {
   return (
-    <th onClick={()=>ordenarPor(key)} style={{cursor:'pointer'}}>
+    <th
+      scope="col"
+      className="px-4 py-2 text-left font-medium cursor-pointer"
+      onClick={()=>ordenarPor(key)}
+    >
       {label} {sortKey===key ? (asc?'⬆':'⬇') : '⬍'}
     </th>
   );
@@ -21,34 +25,58 @@ function formatBR(iso:string){ const [y,m,d]=iso.split('-'); return `${d}/${m}/$
 
 export default function DesignacaoTable({data, ordenarPor, sortKey, asc, onEditar, onDeletar}:Props){
   return (
-    <table>
-      <thead>
-        <tr>
-          {th('ID','id',sortKey,asc,ordenarPor)}
-          {th('Território','territorio',sortKey,asc,ordenarPor)}
-          {th('Saída','saida',sortKey,asc,ordenarPor)}
-          {th('Dia','dia_semana',sortKey,asc,ordenarPor)}
-          {th('Designação','data_designacao',sortKey,asc,ordenarPor)}
-          {th('Devolução','data_devolucao',sortKey,asc,ordenarPor)}
-          <th>Ações</th>
-        </tr>
-      </thead>
-      <tbody>
-        {data.map(item=>(
-          <tr key={item.id}>
-            <td>{item.id}</td>
-            <td>{item.territorio}</td>
-            <td>{item.saida}</td>
-            <td>{item.dia_semana}</td>
-            <td>{formatBR(item.data_designacao)}</td>
-            <td>{formatBR(item.data_devolucao)}</td>
-            <td>
-              <button onClick={()=>onEditar(item.id)}>Editar</button>
-              <button onClick={()=>onDeletar(item.id)}>Excluir</button>
-            </td>
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-sm">
+        <caption className="sr-only">Tabela de Designações</caption>
+        <thead className="bg-gray-100 text-gray-700 hidden sm:table-header-group">
+          <tr>
+            {th('ID','id',sortKey,asc,ordenarPor)}
+            {th('Território','territorio',sortKey,asc,ordenarPor)}
+            {th('Saída','saida',sortKey,asc,ordenarPor)}
+            {th('Dia','dia_semana',sortKey,asc,ordenarPor)}
+            {th('Designação','data_designacao',sortKey,asc,ordenarPor)}
+            {th('Devolução','data_devolucao',sortKey,asc,ordenarPor)}
+            <th scope="col" className="px-4 py-2 text-left font-medium">Ações</th>
           </tr>
-        ))}
-      </tbody>
-    </table>
+        </thead>
+        <tbody className="divide-y divide-gray-200">
+          {data.map(item=>(
+            <tr key={item.id} className="block sm:table-row border border-gray-200 rounded mb-2 sm:border-0 sm:rounded-none">
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">ID</span>
+                {item.id}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Território</span>
+                {item.territorio}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Saída</span>
+                {item.saida}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Dia</span>
+                {item.dia_semana}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Designação</span>
+                {formatBR(item.data_designacao)}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Devolução</span>
+                {formatBR(item.data_devolucao)}
+              </td>
+              <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                <span className="font-semibold sm:hidden">Ações</span>
+                <div className="space-x-2">
+                  <button onClick={()=>onEditar(item.id)}>Editar</button>
+                  <button onClick={()=>onDeletar(item.id)}>Excluir</button>
+                </div>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/renderer/src/components/ReportsTable.tsx
+++ b/renderer/src/components/ReportsTable.tsx
@@ -14,29 +14,46 @@ export default function ReportsTable({ data }: Props){
   return (
     <div className="card">
       <h2>📋 Dados do Relatório</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Território</th>
-            <th>Saída</th>
-            <th>Designação</th>
-            <th>Devolução</th>
-          </tr>
-        </thead>
-        <tbody id="relatorio-table">
-          {data.length === 0 && (
-            <tr><td colSpan={4}>Nenhuma designação encontrada.</td></tr>
-          )}
-          {data.map((d)=>(
-            <tr key={d.id}>
-              <td>{d.territorio}</td>
-              <td>{d.saida} ({d.dia_semana})</td>
-              <td>{formatBR(d.data_designacao)}</td>
-              <td>{formatBR(d.data_devolucao)}</td>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <caption className="sr-only">Tabela de Relatório</caption>
+          <thead className="bg-gray-100 text-gray-700 hidden sm:table-header-group">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Território</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Saída</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Designação</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Devolução</th>
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody id="relatorio-table" className="divide-y divide-gray-200">
+            {data.length === 0 && (
+              <tr className="block sm:table-row">
+                <td colSpan={4} className="px-2 py-2 sm:px-4 sm:py-2">Nenhuma designação encontrada.</td>
+              </tr>
+            )}
+            {data.map((d)=>(
+              <tr key={d.id} className="block sm:table-row border border-gray-200 rounded mb-2 sm:border-0 sm:rounded-none">
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Território</span>
+                  {d.territorio}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Saída</span>
+                  {d.saida} ({d.dia_semana})
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Designação</span>
+                  {formatBR(d.data_designacao)}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Devolução</span>
+                  {formatBR(d.data_devolucao)}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/renderer/src/components/SaidasTable.tsx
+++ b/renderer/src/components/SaidasTable.tsx
@@ -10,25 +10,49 @@ export default function SaidasTable({ data, onEditar, onDeletar }: Props){
   return (
     <div className="card">
       <h2>Lista de Saídas</h2>
-      <table>
-        <thead>
-          <tr><th>ID</th><th>Nome</th><th>Dia</th><th>Ações</th></tr>
-        </thead>
-        <tbody>
-          {data.map(s=>(
-            <tr key={s.id}>
-              <td>{s.id}</td>
-              <td>{s.nome}</td>
-              <td>{s.dia_semana}</td>
-              <td>
-                <button onClick={()=>onEditar(s.id)}>Editar</button>
-                <button onClick={()=>onDeletar(s.id)}>Excluir</button>
-              </td>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <caption className="sr-only">Tabela de Saídas</caption>
+          <thead className="bg-gray-100 text-gray-700 hidden sm:table-header-group">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left font-medium">ID</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Nome</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Dia</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Ações</th>
             </tr>
-          ))}
-          {data.length===0 && <tr><td colSpan={4}>Nenhuma saída cadastrada.</td></tr>}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {data.map(s=>(
+              <tr key={s.id} className="block sm:table-row border border-gray-200 rounded mb-2 sm:border-0 sm:rounded-none">
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">ID</span>
+                  {s.id}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Nome</span>
+                  {s.nome}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Dia</span>
+                  {s.dia_semana}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Ações</span>
+                  <div className="space-x-2">
+                    <button onClick={()=>onEditar(s.id)}>Editar</button>
+                    <button onClick={()=>onDeletar(s.id)}>Excluir</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {data.length===0 && (
+              <tr className="block sm:table-row">
+                <td colSpan={4} className="px-2 py-2 sm:px-4 sm:py-2">Nenhuma saída cadastrada.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }

--- a/renderer/src/components/SugestoesTable.tsx
+++ b/renderer/src/components/SugestoesTable.tsx
@@ -22,52 +22,64 @@ export default function SugestoesTable({
   return (
     <div className="card">
       <h2>Sugestões Geradas</h2>
-      <table>
-        <thead>
-          <tr>
-            <th>Saída</th>
-            <th>Territórios Sugeridos</th>
-            <th>Ações</th>
-          </tr>
-        </thead>
-        <tbody>
-          {sugestoes.map(item => {
-            const selectId = `sel-${item.saida.id}`;
-            const aplicando = aplicandoId === String(item.saida.id);
-            return (
-              <tr key={item.saida.id}>
-                <td>{item.saida.nome} ({item.saida.dia_semana})</td>
-                <td>
-                  {item.territorios.length ? (
-                    <select id={selectId} defaultValue={item.territorios[0].id}>
-                      {item.territorios.map(t => (
-                        <option key={t.id} value={t.id}>{t.descricao}</option>
-                      ))}
-                    </select>
-                  ) : (
-                    <span>Nenhum disponível</span>
-                  )}
-                </td>
-                <td>
-                  <button
-                    disabled={!item.territorios.length || aplicando}
-                    onClick={() => {
-                      const el = document.getElementById(selectId) as HTMLSelectElement | null;
-                      const territorioId = Number(el?.value);
-                      onAplicar(item.saida.id, territorioId);
-                    }}
-                  >
-                    {aplicando ? 'Aplicando...' : 'Aplicar Sugestão'}
-                  </button>
-                </td>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <caption className="sr-only">Tabela de Sugestões</caption>
+          <thead className="bg-gray-100 text-gray-700 hidden sm:table-header-group">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Saída</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Territórios Sugeridos</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Ações</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {sugestoes.map(item => {
+              const selectId = `sel-${item.saida.id}`;
+              const aplicando = aplicandoId === String(item.saida.id);
+              return (
+                <tr key={item.saida.id} className="block sm:table-row border border-gray-200 rounded mb-2 sm:border-0 sm:rounded-none">
+                  <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                    <span className="font-semibold sm:hidden">Saída</span>
+                    {item.saida.nome} ({item.saida.dia_semana})
+                  </td>
+                  <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                    <span className="font-semibold sm:hidden">Territórios Sugeridos</span>
+                    {item.territorios.length ? (
+                      <select id={selectId} defaultValue={item.territorios[0].id}>
+                        {item.territorios.map(t => (
+                          <option key={t.id} value={t.id}>{t.descricao}</option>
+                        ))}
+                      </select>
+                    ) : (
+                      <span>Nenhum disponível</span>
+                    )}
+                  </td>
+                  <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                    <span className="font-semibold sm:hidden">Ações</span>
+                    <div>
+                      <button
+                        disabled={!item.territorios.length || aplicando}
+                        onClick={() => {
+                          const el = document.getElementById(selectId) as HTMLSelectElement | null;
+                          const territorioId = Number(el?.value);
+                          onAplicar(item.saida.id, territorioId);
+                        }}
+                      >
+                        {aplicando ? 'Aplicando...' : 'Aplicar Sugestão'}
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {!sugestoes.length && (
+              <tr className="block sm:table-row">
+                <td colSpan={3} className="px-2 py-2 sm:px-4 sm:py-2">Gere sugestões informando o período.</td>
               </tr>
-            );
-          })}
-          {!sugestoes.length && (
-            <tr><td colSpan={3}>Gere sugestões informando o período.</td></tr>
-          )}
-        </tbody>
-      </table>
+            )}
+          </tbody>
+        </table>
+      </div>
       {sugestoes.length>0 && !temSugestoes && (
         <p style={{marginTop:8}}>Nenhum território disponível para nenhuma saída neste período.</p>
       )}

--- a/renderer/src/components/TerritoriosTable.tsx
+++ b/renderer/src/components/TerritoriosTable.tsx
@@ -13,24 +13,44 @@ export default function TerritoriosTable({ data, onEditar, onDeletar }:Props){
   return (
     <div className="card">
       <h2>Lista de Territórios</h2>
-      <table>
-        <thead>
-          <tr><th>ID</th><th>Descrição</th><th>Ações</th></tr>
-        </thead>
-        <tbody>
-          {data.map(t=>(
-            <tr key={t.id}>
-              <td>{t.id}</td>
-              <td>{t.descricao}</td>
-              <td>
-                <button onClick={()=>onEditar(t)}><span className="material-icons">edit</span> Editar</button>
-                <button onClick={()=>onDeletar(t.id)}><span className="material-icons">delete</span> Excluir</button>
-              </td>
+      <div className="overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <caption className="sr-only">Tabela de Territórios</caption>
+          <thead className="bg-gray-100 text-gray-700 hidden sm:table-header-group">
+            <tr>
+              <th scope="col" className="px-4 py-2 text-left font-medium">ID</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Descrição</th>
+              <th scope="col" className="px-4 py-2 text-left font-medium">Ações</th>
             </tr>
-          ))}
-          {data.length===0 && <tr><td colSpan={6}>Nenhum território cadastrado.</td></tr>}
-        </tbody>
-      </table>
+          </thead>
+          <tbody className="divide-y divide-gray-200">
+            {data.map(t=>(
+              <tr key={t.id} className="block sm:table-row border border-gray-200 rounded mb-2 sm:border-0 sm:rounded-none">
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">ID</span>
+                  {t.id}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Descrição</span>
+                  {t.descricao}
+                </td>
+                <td className="flex justify-between px-2 py-2 sm:table-cell sm:px-4 sm:py-2">
+                  <span className="font-semibold sm:hidden">Ações</span>
+                  <div className="space-x-2">
+                    <button onClick={()=>onEditar(t)}><span className="material-icons">edit</span> Editar</button>
+                    <button onClick={()=>onDeletar(t.id)}><span className="material-icons">delete</span> Excluir</button>
+                  </div>
+                </td>
+              </tr>
+            ))}
+            {data.length===0 && (
+              <tr className="block sm:table-row">
+                <td colSpan={6} className="px-2 py-2 sm:px-4 sm:py-2">Nenhum território cadastrado.</td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add descriptive captions to tables
- apply responsive card layout for mobile screens
- style headers with Tailwind and set scope="col"

## Testing
- `npm run lint`
- `npm test` *(fails: Cannot find module 'typescript')*


------
https://chatgpt.com/codex/tasks/task_e_68c1ed2fc61c83259fd2198f78401152