### PR TITLE
feat(renderer): add basic i18n support

### DIFF
--- a/renderer/src/App.jsx
+++ b/renderer/src/App.jsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import { Button } from '@/components/ui/button'
 import { Link, Routes, Route, Navigate, useLocation } from 'react-router-dom'
+import { useTranslation, I18nContext } from '@/lib/i18n'
 
 const LandingPage = React.lazy(() => import('@/components/LandingPage'))
 const DesignacoesPage = React.lazy(() => import('@/components/DesignacoesPage'))
@@ -10,28 +11,23 @@ const CalendarPage = React.lazy(() => import('@/components/CalendarPage'))
 const ReportsPage = React.lazy(() => import('@/components/ReportsPage'))
 const SugestoesPage = React.lazy(() => import('@/components/SugestoesPage'))
 
-const TABS = [
-  { id: 'designacoes', label: 'Designações', path: '/designacoes', Comp: DesignacoesPage },
-  { id: 'saidas', label: 'Saídas', path: '/saidas', Comp: SaidasPage },
-  { id: 'territorios', label: 'Territórios', path: '/territorios', Comp: TerritoriosPage },
-  { id: 'calendario', label: 'Calendário', path: '/calendario', Comp: CalendarPage },
-  { id: 'relatorios', label: 'Relatórios', path: '/relatorios', Comp: ReportsPage },
-  { id: 'sugestoes', label: 'Sugestões', path: '/sugestoes', Comp: SugestoesPage },
-]
+
 
 class ErrorBoundary extends React.Component {
   constructor(props){
     super(props); this.state = { error: null }
   }
+  static contextType = I18nContext
   static getDerivedStateFromError(error){ return { error } }
   componentDidCatch(err, info){ console.error('Page error:', err, info) }
   render(){
+    const { t } = this.context
     if (this.state.error) {
       return (
         <div className="text-red-600 bg-red-50 border border-red-200 rounded p-4">
-          <p className="font-medium mb-1">Falha ao carregar a página.</p>
+          <p className="font-medium mb-1">{t('error.pageLoadFail')}</p>
           <p className="text-sm text-red-700">
-            Verifique os imports internos. Ex.: use "@/services/api" e "@/types".
+            {t('error.checkImports')}
           </p>
         </div>
       )
@@ -42,12 +38,21 @@ class ErrorBoundary extends React.Component {
 
 export default function App() {
   const location = useLocation()
+  const { t } = useTranslation()
+  const TABS = [
+    { id: 'designacoes', label: t('tabs.designacoes'), path: '/designacoes', Comp: DesignacoesPage },
+    { id: 'saidas', label: t('tabs.saidas'), path: '/saidas', Comp: SaidasPage },
+    { id: 'territorios', label: t('tabs.territorios'), path: '/territorios', Comp: TerritoriosPage },
+    { id: 'calendario', label: t('tabs.calendario'), path: '/calendario', Comp: CalendarPage },
+    { id: 'relatorios', label: t('tabs.relatorios'), path: '/relatorios', Comp: ReportsPage },
+    { id: 'sugestoes', label: t('tabs.sugestoes'), path: '/sugestoes', Comp: SugestoesPage },
+  ]
 
   return (
     <div className="min-h-dvh bg-background text-foreground">
       <header className="border-b">
         <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between gap-4">
-          <h1 className="text-xl font-semibold"><Link to="/">Assigna</Link></h1>
+          <h1 className="text-xl font-semibold"><Link to="/">{t('app.title')}</Link></h1>
           <nav className="flex gap-2 flex-wrap">
 
 
@@ -56,12 +61,12 @@ export default function App() {
       </header>
 
       <main className="max-w-6xl mx-auto px-4 py-6">
-        <React.Suspense fallback={<div>Carregando...</div>}>
+        <React.Suspense fallback={<div>{t('loading')}</div>}>
           <ErrorBoundary>
             <Routes>
               <Route path="/" element={<LandingPage />} />
-              {TABS.map(t => (
-                <Route key={t.id} path={t.path} element={<t.Comp />} />
+              {TABS.map(tab => (
+                <Route key={tab.id} path={tab.path} element={<tab.Comp />} />
               ))}
               <Route path="*" element={<Navigate to="/" replace />} />
             </Routes>

--- a/renderer/src/components/LandingPage.tsx
+++ b/renderer/src/components/LandingPage.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useState } from 'react'
 import { api } from '../services/api'
+import { useTranslation } from '@/lib/i18n'
 
 export default function LandingPage() {
   const [totalSaidas, setTotalSaidas] = useState<number | null>(null)
+  const { t } = useTranslation()
 
   useEffect(() => {
     api?.saidas?.listar?.()
@@ -15,49 +17,49 @@ export default function LandingPage() {
 
   return (
     <div className="max-w-6xl mx-auto px-4 py-6">
-      <h1 className="text-2xl font-semibold">Assigna</h1>
-      <p className="text-muted-foreground mb-6">Escolha um módulo para começar.</p>
+      <h1 className="text-2xl font-semibold">{t('landing.title')}</h1>
+      <p className="text-muted-foreground mb-6">{t('landing.subtitle')}</p>
 
       <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Territórios</h2>
-          <p>Gerencie territórios e dados relacionados.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.territories.title')}</h2>
+          <p>{t('landing.territories.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.territories.dev')}</p>
         </div>
 
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Saídas</h2>
-          <p>Gerencie saídas de campo.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.saidas.title')}</h2>
+          <p>{t('landing.saidas.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.saidas.dev')}</p>
           <p className="text-sm text-muted-foreground">
             {totalSaidas === null
-              ? 'Carregando informações…'
-              : `Total de saídas cadastradas: ${totalSaidas}`}
+              ? t('landing.saidas.loading')
+              : t('landing.saidas.total', { total: totalSaidas })}
           </p>
         </div>
 
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Designações</h2>
-          <p>Crie e acompanhe designações.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.designacoes.title')}</h2>
+          <p>{t('landing.designacoes.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.designacoes.dev')}</p>
         </div>
 
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Relatórios</h2>
-          <p>Gere relatórios e exportações.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.relatorios.title')}</h2>
+          <p>{t('landing.relatorios.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.relatorios.dev')}</p>
         </div>
 
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Mapa</h2>
-          <p>Visualize dados no mapa.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.mapa.title')}</h2>
+          <p>{t('landing.mapa.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.mapa.dev')}</p>
         </div>
 
         <div className="border rounded-lg p-4">
-          <h2 className="font-medium mb-1">Calendário</h2>
-          <p>Consulte o calendário.</p>
-          <p className="text-sm text-muted-foreground">Módulo em desenvolvimento.</p>
+          <h2 className="font-medium mb-1">{t('landing.calendario.title')}</h2>
+          <p>{t('landing.calendario.desc')}</p>
+          <p className="text-sm text-muted-foreground">{t('landing.calendario.dev')}</p>
         </div>
       </div>
     </div>

--- a/renderer/src/lib/i18n.ts
+++ b/renderer/src/lib/i18n.ts
@@ -1,0 +1,50 @@
+import { createContext, useContext, useState, ReactNode } from 'react'
+import pt from '../locales/pt.json'
+import en from '../locales/en.json'
+
+type Lang = 'pt' | 'en'
+type Dict = typeof pt
+
+interface I18nContextType {
+  lang: Lang
+  t: (key: string, vars?: Record<string, any>) => string
+  setLang: (lang: Lang) => void
+}
+
+const translations: Record<Lang, Dict> = { pt, en }
+
+export const I18nContext = createContext<I18nContextType>({
+  lang: 'pt',
+  t: (k) => k,
+  setLang: () => undefined,
+})
+
+export function I18nProvider({ children }: { children: ReactNode }) {
+  const stored = (typeof localStorage !== 'undefined' && localStorage.getItem('lang')) as Lang | null
+  const [lang, setLangState] = useState<Lang>(stored || 'pt')
+
+  function t(key: string, vars?: Record<string, any>) {
+    const parts = key.split('.')
+    let value: any = translations[lang]
+    for (const p of parts) value = value?.[p]
+    if (typeof value !== 'string') return key
+    return value.replace(/{{(\w+)}}/g, (_, v) => String(vars?.[v] ?? ''))
+  }
+
+  function setLang(l: Lang) {
+    setLangState(l)
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('lang', l)
+    }
+  }
+
+  return (
+    <I18nContext.Provider value={{ lang, t, setLang }}>
+      {children}
+    </I18nContext.Provider>
+  )
+}
+
+export function useTranslation() {
+  return useContext(I18nContext)
+}

--- a/renderer/src/locales/en.json
+++ b/renderer/src/locales/en.json
@@ -1,0 +1,54 @@
+{
+  "app": {
+    "title": "Assigna"
+  },
+  "tabs": {
+    "designacoes": "Assignments",
+    "saidas": "Outings",
+    "territorios": "Territories",
+    "calendario": "Calendar",
+    "relatorios": "Reports",
+    "sugestoes": "Suggestions"
+  },
+  "error": {
+    "pageLoadFail": "Failed to load page.",
+    "checkImports": "Check internal imports. E.g., use \"@/services/api\" and \"@/types\"."
+  },
+  "loading": "Loading...",
+  "landing": {
+    "title": "Assigna",
+    "subtitle": "Choose a module to start.",
+    "territories": {
+      "title": "Territories",
+      "desc": "Manage territories and related data.",
+      "dev": "Module under development."
+    },
+    "saidas": {
+      "title": "Outings",
+      "desc": "Manage field outings.",
+      "dev": "Module under development.",
+      "loading": "Loading information…",
+      "total": "Total registered outings: {{total}}"
+    },
+    "designacoes": {
+      "title": "Assignments",
+      "desc": "Create and track assignments.",
+      "dev": "Module under development."
+    },
+    "relatorios": {
+      "title": "Reports",
+      "desc": "Generate reports and exports.",
+      "dev": "Module under development."
+    },
+    "mapa": {
+      "title": "Map",
+      "desc": "View data on the map.",
+      "dev": "Module under development."
+    },
+    "calendario": {
+      "title": "Calendar",
+      "desc": "Check the calendar.",
+      "dev": "Module under development."
+    }
+  }
+}

--- a/renderer/src/locales/pt.json
+++ b/renderer/src/locales/pt.json
@@ -1,0 +1,54 @@
+{
+  "app": {
+    "title": "Assigna"
+  },
+  "tabs": {
+    "designacoes": "Designações",
+    "saidas": "Saídas",
+    "territorios": "Territórios",
+    "calendario": "Calendário",
+    "relatorios": "Relatórios",
+    "sugestoes": "Sugestões"
+  },
+  "error": {
+    "pageLoadFail": "Falha ao carregar a página.",
+    "checkImports": "Verifique os imports internos. Ex.: use \"@/services/api\" e \"@/types\"."
+  },
+  "loading": "Carregando...",
+  "landing": {
+    "title": "Assigna",
+    "subtitle": "Escolha um módulo para começar.",
+    "territories": {
+      "title": "Territórios",
+      "desc": "Gerencie territórios e dados relacionados.",
+      "dev": "Módulo em desenvolvimento."
+    },
+    "saidas": {
+      "title": "Saídas",
+      "desc": "Gerencie saídas de campo.",
+      "dev": "Módulo em desenvolvimento.",
+      "loading": "Carregando informações…",
+      "total": "Total de saídas cadastradas: {{total}}"
+    },
+    "designacoes": {
+      "title": "Designações",
+      "desc": "Crie e acompanhe designações.",
+      "dev": "Módulo em desenvolvimento."
+    },
+    "relatorios": {
+      "title": "Relatórios",
+      "desc": "Gere relatórios e exportações.",
+      "dev": "Módulo em desenvolvimento."
+    },
+    "mapa": {
+      "title": "Mapa",
+      "desc": "Visualize dados no mapa.",
+      "dev": "Módulo em desenvolvimento."
+    },
+    "calendario": {
+      "title": "Calendário",
+      "desc": "Consulte o calendário.",
+      "dev": "Módulo em desenvolvimento."
+    }
+  }
+}

--- a/renderer/src/main.jsx
+++ b/renderer/src/main.jsx
@@ -5,13 +5,16 @@ import './index.css'
 import { ToastProvider } from './components/ui/toast'
 import { ConfirmProvider } from './components/ui/confirm-dialog'
 import { BrowserRouter } from 'react-router-dom'
+import { I18nProvider } from './lib/i18n'
 
 createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ToastProvider>
       <ConfirmProvider>
         <BrowserRouter>
-          <App />
+          <I18nProvider>
+            <App />
+          </I18nProvider>
         </BrowserRouter>
       </ConfirmProvider>
     </ToastProvider>


### PR DESCRIPTION
## Summary
- add simple i18n context with locale files
- use translation hooks in App and LandingPage

## Testing
- `npm run lint`
- `npm test` (fails: test failed)


------
https://chatgpt.com/codex/tasks/task_e_68c1ee0e56108325875c1bd5756a9a98