### PR TITLE
feat: add territory form validation and filtering

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
   },
   "dependencies": {
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-hook-form": "^7.49.3",
+    "@hookform/resolvers": "^3.3.2",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",


### PR DESCRIPTION
## Summary
- integrate zod and react-hook-form
- add territory create/edit form with validation
- add territory list search, filter and pagination

## Testing
- `npm test` (fails: vitest not found)
- `npm run lint` (fails: ESLint couldn't find configuration)


------
https://chatgpt.com/codex/tasks/task_e_68c2d8c9e084832589a174778b43ea80