### PR TITLE
feat: add IndexedDB persistence with Dexie

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "react-dom": "^18.3.1",
     "react-hook-form": "^7.49.3",
     "@hookform/resolvers": "^3.3.2",
-    "zod": "^3.23.8"
+    "zod": "^3.23.8",
+    "dexie": "^3.2.4"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",
@@ -34,6 +35,7 @@
     "typescript": "^5.5.4",
     "vite": "^5.4.2",
     "vitest": "^1.6.1",
-    "jsdom": "^24.0.0"
+    "jsdom": "^24.0.0",
+    "fake-indexeddb": "^5.0.2"
   }
 }

--- a/src/services/db/index.test.ts
+++ b/src/services/db/index.test.ts
@@ -1,0 +1,21 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeAll } from 'vitest';
+import { db, migrate } from './index';
+import { TerritorioRepository } from './repositories';
+
+describe('IndexedDB persistence', () => {
+  beforeAll(async () => {
+    await db.delete();
+    await migrate();
+  });
+
+  it('stores and retrieves many territorios', async () => {
+    const territorios = Array.from({ length: 1000 }, (_, i) => ({
+      id: `${i}`,
+      nome: `Territorio ${i}`
+    }));
+    await TerritorioRepository.bulkAdd(territorios);
+    const all = await TerritorioRepository.all();
+    expect(all.length).toBe(territorios.length);
+  });
+});

--- a/src/services/db/index.ts
+++ b/src/services/db/index.ts
@@ -1,0 +1,45 @@
+import Dexie, { Table } from 'dexie';
+import type { Territorio, Saida, Designacao, Sugestao } from '../../types';
+
+export interface Metadata {
+  key: string;
+  value: number;
+}
+
+class AppDB extends Dexie {
+  territorios!: Table<Territorio, string>;
+  saidas!: Table<Saida, string>;
+  designacoes!: Table<Designacao, string>;
+  sugestoes!: Table<Sugestao, string>;
+  metadata!: Table<Metadata, string>;
+
+  constructor() {
+    super('assigna');
+    this.version(1).stores({
+      territorios: 'id, nome',
+      saidas: 'id, nome, diaDaSemana',
+      designacoes: 'id, territorioId, saidaId',
+      sugestoes: '[territorioId+saidaId]',
+      metadata: 'key'
+    });
+  }
+}
+
+export const db = new AppDB();
+export const SCHEMA_VERSION = 1;
+
+export async function getSchemaVersion(): Promise<number> {
+  const meta = await db.metadata.get('schemaVersion');
+  return meta?.value ?? 0;
+}
+
+export async function setSchemaVersion(version: number): Promise<void> {
+  await db.metadata.put({ key: 'schemaVersion', value: version });
+}
+
+export async function migrate(): Promise<void> {
+  const current = await getSchemaVersion();
+  if (current < SCHEMA_VERSION) {
+    await setSchemaVersion(SCHEMA_VERSION);
+  }
+}

--- a/src/services/db/repositories/designacoes.ts
+++ b/src/services/db/repositories/designacoes.ts
@@ -1,0 +1,17 @@
+import type { Designacao } from '../../../types';
+import { db } from '../index';
+
+export const DesignacaoRepository = {
+  async all(): Promise<Designacao[]> {
+    return db.designacoes.toArray();
+  },
+  async add(designacao: Designacao): Promise<void> {
+    await db.designacoes.put(designacao);
+  },
+  async bulkAdd(designacoes: Designacao[]): Promise<void> {
+    await db.designacoes.bulkPut(designacoes);
+  },
+  async remove(id: string): Promise<void> {
+    await db.designacoes.delete(id);
+  }
+};

--- a/src/services/db/repositories/index.ts
+++ b/src/services/db/repositories/index.ts
@@ -1,0 +1,4 @@
+export * from './territorios';
+export * from './saidas';
+export * from './designacoes';
+export * from './sugestoes';

--- a/src/services/db/repositories/saidas.ts
+++ b/src/services/db/repositories/saidas.ts
@@ -1,0 +1,17 @@
+import type { Saida } from '../../../types';
+import { db } from '../index';
+
+export const SaidaRepository = {
+  async all(): Promise<Saida[]> {
+    return db.saidas.toArray();
+  },
+  async add(saida: Saida): Promise<void> {
+    await db.saidas.put(saida);
+  },
+  async bulkAdd(saidas: Saida[]): Promise<void> {
+    await db.saidas.bulkPut(saidas);
+  },
+  async remove(id: string): Promise<void> {
+    await db.saidas.delete(id);
+  }
+};

--- a/src/services/db/repositories/sugestoes.ts
+++ b/src/services/db/repositories/sugestoes.ts
@@ -1,0 +1,17 @@
+import type { Sugestao } from '../../../types';
+import { db } from '../index';
+
+export const SugestaoRepository = {
+  async all(): Promise<Sugestao[]> {
+    return db.sugestoes.toArray();
+  },
+  async add(sugestao: Sugestao): Promise<void> {
+    await db.sugestoes.put(sugestao);
+  },
+  async bulkAdd(sugestoes: Sugestao[]): Promise<void> {
+    await db.sugestoes.bulkPut(sugestoes);
+  },
+  async remove(territorioId: string, saidaId: string): Promise<void> {
+    await db.sugestoes.delete([territorioId, saidaId]);
+  }
+};

--- a/src/services/db/repositories/territorios.ts
+++ b/src/services/db/repositories/territorios.ts
@@ -1,0 +1,17 @@
+import type { Territorio } from '../../../types';
+import { db } from '../index';
+
+export const TerritorioRepository = {
+  async all(): Promise<Territorio[]> {
+    return db.territorios.toArray();
+  },
+  async add(territorio: Territorio): Promise<void> {
+    await db.territorios.put(territorio);
+  },
+  async bulkAdd(territorios: Territorio[]): Promise<void> {
+    await db.territorios.bulkPut(territorios);
+  },
+  async remove(id: string): Promise<void> {
+    await db.territorios.delete(id);
+  }
+};


### PR DESCRIPTION
## Summary
- add Dexie-based IndexedDB database with schema versioning
- create repositories for entities (Territorio, Saida, Designacao, Sugestao)
- add initial tests demonstrating large dataset handling

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e5279ad48325a709e82713bb1a0f