### PR TITLE
feat: add monthly export scheduler

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { useToast } from "./components/Toast";
 import { useConfirm } from "./components/ConfirmDialog";
 import { StatusBadge } from "./components/Badge";
 import { Modal } from "./components/Modal";
+import { SchedulerControls } from "./components/SchedulerControls";
 // ---------- Types ----------
  type ID = string;
  type Territory = { id: ID; name: string; image?: string };
@@ -803,6 +804,7 @@ export default function App(){
         {tab==='assignments' && <AssignmentsPage />}
         {tab==='calendar' && <CalendarPage />}
         {tab==='suggestions' && <SuggestionsPage />}
+        <SchedulerControls />
         <div className="flex justify-end">
           <Button onClick={async()=>{ if(await confirm('Limpar TODOS os dados?')) store.clearAll(); }} className="mt-4 bg-red-600 text-white">Limpar TODOS os dados</Button>
         </div>

--- a/src/components/SchedulerControls.tsx
+++ b/src/components/SchedulerControls.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+import { useMonthlyExportScheduler } from '../hooks/useMonthlyExportScheduler';
+
+export const SchedulerControls: React.FC = () => {
+  const { config, setConfig } = useMonthlyExportScheduler();
+  const dateValue = new Date(config.nextRun).toISOString().slice(0, 16);
+
+  return (
+    <div className="border rounded-xl p-4 mt-4">
+      <h2 className="text-lg font-semibold mb-2">Exportação mensal</h2>
+      <label className="flex items-center gap-2">
+        <input
+          type="checkbox"
+          checked={config.enabled}
+          onChange={(e) => setConfig({ ...config, enabled: e.target.checked })}
+        />
+        <span>Ativar</span>
+      </label>
+      <div className="mt-2">
+        <span className="text-sm text-neutral-600 mr-2">Próxima execução:</span>
+        <input
+          type="datetime-local"
+          value={dateValue}
+          onChange={(e) =>
+            setConfig({ ...config, nextRun: new Date(e.target.value).getTime() })
+          }
+          className="rounded border px-2 py-1"
+        />
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- add hook to schedule monthly CSV export
- display scheduler controls to enable/disable and set next run
- trigger export using monthly summary and CSV download

## Testing
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c3048796cc83259b1fa57b9104d11d