### PR TITLE
feat: add internationalization

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,9 @@
     "react-hook-form": "^7.49.3",
     "@hookform/resolvers": "^3.3.2",
     "zod": "^3.23.8",
-    "dexie": "^3.2.4"
+    "dexie": "^3.2.4",
+    "i18next": "^23.7.15",
+    "react-i18next": "^15.5.1"
   },
   "devDependencies": {
     "@types/react": "^18.3.3",

--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 
 interface Props {
   status: 'ativo' | 'devolvido' | 'atrasado';
@@ -10,13 +11,10 @@ const colors: Record<Props['status'], string> = {
   atrasado: 'bg-red-600',
 };
 
-const labels: Record<Props['status'], string> = {
-  ativo: 'Ativo',
-  devolvido: 'Devolvido',
-  atrasado: 'Atrasado',
+export const StatusBadge: React.FC<Props> = ({ status }) => {
+  const { t } = useTranslation();
+  return (
+    <span className={`text-xs text-white px-2 py-1 rounded ${colors[status]}`}>{t(`status.${status}`)}</span>
+  );
 };
-
-export const StatusBadge: React.FC<Props> = ({ status }) => (
-  <span className={`text-xs text-white px-2 py-1 rounded ${colors[status]}`}>{labels[status]}</span>
-);
 

--- a/src/components/ConfirmDialog.tsx
+++ b/src/components/ConfirmDialog.tsx
@@ -1,5 +1,6 @@
 import React, { createContext, useContext, useState } from 'react';
 import { Modal } from './Modal';
+import { useTranslation } from 'react-i18next';
 
 interface ConfirmState {
   message: string;
@@ -12,6 +13,7 @@ export const useConfirm = () => useContext(ConfirmContext);
 
 export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [state, setState] = useState<ConfirmState | null>(null);
+  const { t } = useTranslation();
 
   const confirm = (message: string) => new Promise<boolean>((resolve) => setState({ message, resolve }));
 
@@ -27,12 +29,14 @@ export const ConfirmProvider: React.FC<{ children: React.ReactNode }> = ({ child
         <Modal>
           <p className="mb-4">{state.message}</p>
           <div className="flex justify-end gap-2">
-            <button onClick={() => handle(false)} className="px-3 py-2 rounded-xl border">Cancelar</button>
+            <button onClick={() => handle(false)} className="px-3 py-2 rounded-xl border">
+              {t('confirm.cancel')}
+            </button>
             <button
               onClick={() => handle(true)}
               className="px-3 py-2 rounded-xl border bg-red-600 text-white"
             >
-              Confirmar
+              {t('confirm.confirm')}
             </button>
           </div>
         </Modal>

--- a/src/components/LanguageSelector.tsx
+++ b/src/components/LanguageSelector.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+
+export const LanguageSelector: React.FC = () => {
+  const { i18n, t } = useTranslation();
+
+  const change = (e: React.ChangeEvent<HTMLSelectElement>) => {
+    const lng = e.target.value;
+    i18n.changeLanguage(lng);
+    if (typeof window !== 'undefined') {
+      localStorage.setItem('locale', lng);
+    }
+  };
+
+  return (
+    <select value={i18n.language} onChange={change} className="border rounded px-2 py-1">
+      <option value="en-US">{t('language.english')}</option>
+      <option value="pt-BR">{t('language.portuguese')}</option>
+    </select>
+  );
+};

--- a/src/components/NavBar.tsx
+++ b/src/components/NavBar.tsx
@@ -1,10 +1,19 @@
+import React from 'react';
+import { useTranslation } from 'react-i18next';
+import { LanguageSelector } from './LanguageSelector';
+
 interface Props {
   navigate: (page: 'home' | 'about') => void;
 }
 
-export const NavBar = ({ navigate }: Props): JSX.Element => (
-  <nav className="flex gap-4 p-4 bg-gray-100">
-    <button onClick={() => navigate('home')}>Home</button>
-    <button onClick={() => navigate('about')}>About</button>
-  </nav>
-);
+export const NavBar = ({ navigate }: Props): JSX.Element => {
+  const { t } = useTranslation();
+
+  return (
+    <nav className="flex gap-4 p-4 bg-gray-100 items-center">
+      <button onClick={() => navigate('home')}>{t('navbar.home')}</button>
+      <button onClick={() => navigate('about')}>{t('navbar.about')}</button>
+      <LanguageSelector />
+    </nav>
+  );
+};

--- a/src/components/SchedulerControls.tsx
+++ b/src/components/SchedulerControls.tsx
@@ -1,23 +1,25 @@
 import React from 'react';
 import { useMonthlyExportScheduler } from '../hooks/useMonthlyExportScheduler';
+import { useTranslation } from 'react-i18next';
 
 export const SchedulerControls: React.FC = () => {
   const { config, setConfig } = useMonthlyExportScheduler();
+  const { t } = useTranslation();
   const dateValue = new Date(config.nextRun).toISOString().slice(0, 16);
 
   return (
     <div className="border rounded-xl p-4 mt-4">
-      <h2 className="text-lg font-semibold mb-2">Exportação mensal</h2>
+      <h2 className="text-lg font-semibold mb-2">{t('scheduler.title')}</h2>
       <label className="flex items-center gap-2">
         <input
           type="checkbox"
           checked={config.enabled}
           onChange={(e) => setConfig({ ...config, enabled: e.target.checked })}
         />
-        <span>Ativar</span>
+        <span>{t('scheduler.enable')}</span>
       </label>
       <div className="mt-2">
-        <span className="text-sm text-neutral-600 mr-2">Próxima execução:</span>
+        <span className="text-sm text-neutral-600 mr-2">{t('scheduler.nextRun')}</span>
         <input
           type="datetime-local"
           value={dateValue}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -47,27 +47,32 @@ const SuggestIcon = () => (
 );
 
 const items = [
-  { id: 'territories', label: 'Territórios', icon: <MapIcon /> },
-  { id: 'exits', label: 'Saídas', icon: <ExitIcon /> },
-  { id: 'assignments', label: 'Designações', icon: <AssignIcon /> },
-  { id: 'calendar', label: 'Calendário', icon: <CalendarIcon /> },
-  { id: 'suggestions', label: 'Sugestões', icon: <SuggestIcon /> },
+  { id: 'territories', label: 'sidebar.territories', icon: <MapIcon /> },
+  { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
+  { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
+  { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },
+  { id: 'suggestions', label: 'sidebar.suggestions', icon: <SuggestIcon /> },
 ];
 
-export const Sidebar: React.FC<Props> = ({ current, onSelect }) => (
-  <nav className="bg-white dark:bg-neutral-900 border-r p-2 flex md:flex-col gap-2 md:w-48">
-    {items.map((it) => (
-      <button
-        key={it.id}
-        onClick={() => onSelect(it.id)}
-        className={`flex items-center gap-2 px-3 py-2 rounded transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
-          current === it.id ? 'bg-neutral-200 dark:bg-neutral-800' : ''
-        }`}
-      >
-        {it.icon}
-        <span className="hidden md:inline">{it.label}</span>
-      </button>
-    ))}
-  </nav>
-);
+import { useTranslation } from 'react-i18next';
+
+export const Sidebar: React.FC<Props> = ({ current, onSelect }) => {
+  const { t } = useTranslation();
+  return (
+    <nav className="bg-white dark:bg-neutral-900 border-r p-2 flex md:flex-col gap-2 md:w-48">
+      {items.map((it) => (
+        <button
+          key={it.id}
+          onClick={() => onSelect(it.id)}
+          className={`flex items-center gap-2 px-3 py-2 rounded transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
+            current === it.id ? 'bg-neutral-200 dark:bg-neutral-800' : ''
+          }`}
+        >
+          {it.icon}
+          <span className="hidden md:inline">{t(it.label)}</span>
+        </button>
+      ))}
+    </nav>
+  );
+};
 

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,20 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en-US/translation.json';
+import pt from './locales/pt-BR/translation.json';
+
+const stored = typeof window !== 'undefined' ? localStorage.getItem('locale') : null;
+
+i18n
+  .use(initReactI18next)
+  .init({
+    resources: {
+      'en-US': { translation: en },
+      'pt-BR': { translation: pt }
+    },
+    lng: stored || 'en-US',
+    fallbackLng: 'en-US',
+    interpolation: { escapeValue: false }
+  });
+
+export default i18n;

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -1,0 +1,42 @@
+{
+  "home": {
+    "title": "Home",
+    "today": "Today is {{date}}",
+    "exampleNumber": "Example number: {{value}}"
+  },
+  "about": {
+    "title": "About"
+  },
+  "navbar": {
+    "home": "Home",
+    "about": "About"
+  },
+  "confirm": {
+    "cancel": "Cancel",
+    "confirm": "Confirm"
+  },
+  "scheduler": {
+    "title": "Monthly export",
+    "enable": "Enable",
+    "nextRun": "Next run:"
+  },
+  "sidebar": {
+    "territories": "Territories",
+    "exits": "Exits",
+    "assignments": "Assignments",
+    "calendar": "Calendar",
+    "suggestions": "Suggestions"
+  },
+  "status": {
+    "ativo": "Active",
+    "devolvido": "Returned",
+    "atrasado": "Late"
+  },
+  "app": {
+    "updateAvailable": "New version available. Update?"
+  },
+  "language": {
+    "english": "English",
+    "portuguese": "Português"
+  }
+}

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -1,0 +1,42 @@
+{
+  "home": {
+    "title": "Início",
+    "today": "Hoje é {{date}}",
+    "exampleNumber": "Número de exemplo: {{value}}"
+  },
+  "about": {
+    "title": "Sobre"
+  },
+  "navbar": {
+    "home": "Início",
+    "about": "Sobre"
+  },
+  "confirm": {
+    "cancel": "Cancelar",
+    "confirm": "Confirmar"
+  },
+  "scheduler": {
+    "title": "Exportação mensal",
+    "enable": "Ativar",
+    "nextRun": "Próxima execução:"
+  },
+  "sidebar": {
+    "territories": "Territórios",
+    "exits": "Saídas",
+    "assignments": "Designações",
+    "calendar": "Calendário",
+    "suggestions": "Sugestões"
+  },
+  "status": {
+    "ativo": "Ativo",
+    "devolvido": "Devolvido",
+    "atrasado": "Atrasado"
+  },
+  "app": {
+    "updateAvailable": "Nova versão disponível. Atualizar?"
+  },
+  "language": {
+    "english": "English",
+    "portuguese": "Português"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import './index.css';
 import { AppProvider } from './store/AppContext';
 import { ToastProvider } from './components/Toast';
 import { ConfirmProvider } from './components/ConfirmDialog';
+import i18n from './i18n';
 
 if ('serviceWorker' in navigator) {
   let refreshing = false;
@@ -15,7 +16,7 @@ if ('serviceWorker' in navigator) {
         if (newWorker) {
           newWorker.addEventListener('statechange', () => {
             if (newWorker.state === 'installed' && navigator.serviceWorker.controller) {
-              if (confirm('Nova versão disponível. Atualizar?')) {
+              if (confirm(i18n.t('app.updateAvailable'))) {
                 newWorker.postMessage({ type: 'SKIP_WAITING' });
               }
             }

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,3 +1,6 @@
+import { useTranslation } from 'react-i18next';
+
 export default function About(): JSX.Element {
-  return <h1>About</h1>;
+  const { t } = useTranslation();
+  return <h1>{t('about.title')}</h1>;
 }

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,3 +1,16 @@
+import { useTranslation } from 'react-i18next';
+import { formatDate, formatNumber } from '../utils/format';
+
 export default function Home(): JSX.Element {
-  return <h1>Home</h1>;
+  const { t } = useTranslation();
+  const today = formatDate(new Date());
+  const value = formatNumber(1234567.89);
+
+  return (
+    <div>
+      <h1>{t('home.title')}</h1>
+      <p>{t('home.today', { date: today })}</p>
+      <p>{t('home.exampleNumber', { value })}</p>
+    </div>
+  );
 }

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -1,0 +1,9 @@
+import i18n from '../i18n';
+
+export const formatDate = (date: Date): string => {
+  return new Intl.DateTimeFormat(i18n.language).format(date);
+};
+
+export const formatNumber = (value: number): string => {
+  return new Intl.NumberFormat(i18n.language).format(value);
+};


### PR DESCRIPTION
## Summary
- add i18next with English and Portuguese translations
- implement language selector and replace hard-coded text with translation keys
- format dates and numbers using active locale

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/i18next)*
- `npm test` *(fails: vitest: not found)*
- `npm run lint` *(fails: ESLint couldn't find eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68c30c1630f48325a3efb68aa57959be