### PR TITLE
chore: add documentation templates

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,35 @@
+# Código de Conduta do Contribuinte
+
+Este projeto adota o [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
+
+## Nosso Compromisso
+
+Nós, como membros, contribuidores e líderes, comprometemo-nos a tornar a participação em nossa comunidade uma experiência livre de assédio para todos.
+
+## Nossos Padrões
+
+Exemplos de comportamentos que contribuem para criar um ambiente positivo incluem:
+
+- Demonstrar empatia e gentileza com outras pessoas
+- Respeitar opiniões, pontos de vista e experiências contrárias
+- Aceitar feedback construtivo com educação
+- Focar no que é melhor não só para nós individualmente, mas para a comunidade em geral
+
+Comportamentos inaceitáveis incluem:
+
+- Uso de linguagem ou imagens sexualizadas e atenção sexual indesejada
+- Comentários insultuosos ou depreciativos e ataques pessoais ou políticos
+- Assédio público ou privado
+- Qualquer outra conduta que razoavelmente possa ser considerada inadequada em um ambiente profissional
+
+## Aplicação
+
+Casos de abuso, assédio ou qualquer comportamento inaceitável podem ser reportados abrindo uma issue ou contatando os mantenedores.
+
+Todos os relatos serão revisados e investigados prontamente e de forma justa.
+
+Os mantenedores que não seguirem ou aplicarem este Código de Conduta poderão ser removidos temporária ou permanentemente da comunidade.
+
+## Atribuição
+
+Este Código de Conduta é adaptado do [Contributor Covenant, versão 2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contribuindo para Assigna
+
+Agradecemos o interesse em contribuir! Para manter a qualidade do projeto, siga as etapas abaixo:
+
+1. Faça um fork do repositório.
+2. Crie uma branch para sua feature ou correção.
+3. Instale as dependências com `npm install`.
+4. Execute `npm test` para garantir que os testes passam.
+5. Envie um pull request descrevendo suas mudanças.
+
+Certifique-se de ler e seguir o [Código de Conduta](CODE_OF_CONDUCT.md).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,45 @@
-# Territory Manager (Vite + React + Tailwind)
+# Assigna
+Gerencie territórios, saídas e designações de forma offline.
 
-Aplicação SPA para gestão de **Territórios**, **Saídas**, **Designações** e **Sugestões** com regras.
-Tudo salvo em `localStorage` (sem backend).
+## Descrição
+Aplicação SPA para organizar **Territórios**, **Saídas de Campo**, **Designações** e **Sugestões**. Tudo salvo localmente em `localStorage`, sem necessidade de backend.
 
-## Recursos
-- Cadastrar **Territórios** (nome + imagem opcional)
-- Cadastrar **Saídas de Campo** (dia da semana, nome, horário)
-- **Designações** (território, saída, data de designação e devolução)
-- **Sugestões** baseadas em regras (evitar repetição por N meses e duração padrão em dias)
+### Principais Recursos
+- Cadastrar **Territórios** (nome e imagem opcional)
+- Cadastrar **Saídas de Campo** (dia da semana, nome e horário)
+- Registrar **Designações** (território, saída, datas de designação e devolução)
+- Gerar **Sugestões** evitando repetição por N meses e com duração padrão em dias
 
-## Como rodar
+## Requisitos
+- [Node.js](https://nodejs.org) \>= 18
+- Windows, macOS ou Linux
+- Dependências-chave: React, Vite e Tailwind CSS
+
+## Instalação
+1. Clone o repositório.
+2. Instale as dependências com `npm install`.
+3. Inicie o servidor de desenvolvimento usando `npm run dev`.
+
+Para um passo a passo completo, consulte o [guia de instalação](docs/installation.md).
+
+## Uso
 ```bash
-# Requisitos: Node 18+
-npm i
 npm run dev
-# abrir http://localhost:5173
+# abra http://localhost:5173 no navegador
 ```
+Resultado esperado: a aplicação carregará no navegador permitindo gerenciar territórios e designações.
 
-## Build
+## Configuração
+Atualmente não há variáveis de ambiente obrigatórias. Caso precise, crie um arquivo `.env` e defina variáveis como:
 ```bash
-npm run build
-npm run preview
+EXAMPLE_API_KEY="sua_chave_aqui"
 ```
 
-## Tailwind
-Tailwind já está configurado com `darkMode: 'class'`. O botão no topo alterna claro/escuro.
+## Suporte
+Abra uma issue no [rastreador de problemas](../../issues) para relatar bugs ou solicitar recursos.
+
+## Contribuição
+Contribuições são bem-vindas! Veja as diretrizes em [CONTRIBUTING.md](CONTRIBUTING.md) e o [Código de Conduta](CODE_OF_CONDUCT.md).
+
+## Licença
+Distribuído sob a licença [MIT](LICENSE).

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,3 @@
+# Guia de Instalação Completo
+
+Forneça aqui instruções detalhadas de instalação, incluindo pré-requisitos adicionais, configuração avançada e dicas de solução de problemas.


### PR DESCRIPTION
## Summary
- restructure README with project overview and setup instructions
- add contribution guidelines, code of conduct, and license
- provide placeholder detailed installation guide

## Testing
- `npm install --no-progress` (failed: ENOTEMPTY: directory not empty, rename '/workspace/Assigna/node_modules/chalk')
- `npm test` (failed: sh: 1: vitest: not found)

------
https://chatgpt.com/codex/tasks/task_e_68c31597d5308325b75a01526764a47a