### PR TITLE
feat: expand database schema with street and address tables

### DIFF
--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -1,0 +1,7 @@
+export interface Address {
+  id?: number;
+  streetId: number;
+  numberStart: number;
+  numberEnd: number;
+}
+

--- a/src/types/derived-territory.ts
+++ b/src/types/derived-territory.ts
@@ -1,0 +1,6 @@
+export interface DerivedTerritory {
+  id?: number;
+  baseTerritoryId: string;
+  name: string;
+}
+

--- a/src/types/property-type.ts
+++ b/src/types/property-type.ts
@@ -1,0 +1,5 @@
+export interface PropertyType {
+  id?: number;
+  name: string;
+}
+

--- a/src/types/street.ts
+++ b/src/types/street.ts
@@ -1,0 +1,6 @@
+export interface Street {
+  id?: number;
+  territoryId: string;
+  name: string;
+}
+


### PR DESCRIPTION
## Summary
- add tables for streets, property types, addresses and derived territories
- bump schema to version 2 and prepare migration
- define interfaces for new tables

## Testing
- `npm test`
- `npm run lint` *(fails: 'React' must be in scope and unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c31fc51c1c8325b00f8b8f70b626b1