### PR TITLE
feat: add streets tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { useConfirm } from "./components/feedback/ConfirmDialog";
 import { StatusBadge } from "./components/feedback/Badge";
 import { Modal } from "./components/layout/Modal";
 import { SchedulerControls } from "./components/calendar/SchedulerControls";
+import RuasNumeracoesPage from "./pages/RuasNumeracoesPage";
 // ---------- Types ----------
  type ID = string;
  type Territory = { id: ID; name: string; image?: string };
@@ -814,6 +815,7 @@ export default function App(){
     <StoreContext.Provider value={store}>
       <Shell tab={tab} setTab={setTab}>
         {tab==='territories' && <TerritoriesPage />}
+        {tab==='streets' && <RuasNumeracoesPage />}
         {tab==='exits' && <ExitsPage />}
         {tab==='assignments' && <AssignmentsPage />}
         {tab==='calendar' && <CalendarPage />}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -48,6 +48,7 @@ const SuggestIcon = () => (
 
 const items = [
   { id: 'territories', label: 'sidebar.territories', icon: <MapIcon /> },
+  { id: 'streets', label: 'sidebar.streets', icon: <MapIcon /> },
   { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
   { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
   { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -22,6 +22,7 @@
   },
   "sidebar": {
     "territories": "Territories",
+    "streets": "Streets",
     "exits": "Exits",
     "assignments": "Assignments",
     "calendar": "Calendar",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -22,6 +22,7 @@
   },
   "sidebar": {
     "territories": "Territórios",
+    "streets": "Ruas",
     "exits": "Saídas",
     "assignments": "Designações",
     "calendar": "Calendário",

--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+export default function RuasNumeracoesPage(): JSX.Element {
+  return <div>Ruas</div>;
+}


### PR DESCRIPTION
## Summary
- add streets item to sidebar
- handle streets tab rendering RuasNumeracoesPage
- translate new sidebar label to English and Portuguese

## Testing
- `npm test`
- `npm run lint` *(fails: 'React' must be in scope when using JSX in multiple files, missing prop-type, and unexpected any)*

------
https://chatgpt.com/codex/tasks/task_e_68c3269fbbf8832593d2c587ede2663a