### PR TITLE
feat: coerce address numbers

### DIFF
--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -13,7 +13,8 @@ export const addressSchema = z.object({
   id: z.number().optional(),
   streetId: z.coerce.number(),
   numberStart: z.coerce.number(),
-  numberEnd: z.coerce.number()
+  numberEnd: z.coerce.number(),
+  propertyTypeId: z.coerce.number()
 });
 
 export type AddressForm = z.infer<typeof addressSchema>;
@@ -92,7 +93,7 @@ export default function RuasNumeracoesPage(): JSX.Element {
       <div className="border rounded p-2">
         {territory && (
           <ImageAnnotator
-            imageUrl={(territory as any).imageUrl ?? territory.imagem ?? ''}
+            imageUrl={territory.imageUrl ?? territory.imagem ?? ''}
             onAdd={handleAddAddress}
             onUpdate={handleAddAddress}
             onDelete={handleDeleteAddress}
@@ -162,6 +163,17 @@ export default function RuasNumeracoesPage(): JSX.Element {
                     </option>
                   ))}
               </select>
+              <select
+                {...register('propertyTypeId', { valueAsNumber: true })}
+                className="border p-1"
+              >
+                <option value="">Tipo</option>
+                {propertyTypes.map(pt => (
+                  <option key={pt.id} value={pt.id}>
+                    {pt.name}
+                  </option>
+                ))}
+              </select>
               <input
                 type="number"
                 placeholder="Início"
@@ -184,6 +196,7 @@ export default function RuasNumeracoesPage(): JSX.Element {
                   <th className="text-left">Rua</th>
                   <th className="text-left">Início</th>
                   <th className="text-left">Fim</th>
+                  <th className="text-left">Tipo</th>
                 </tr>
               </thead>
               <tbody>
@@ -192,6 +205,7 @@ export default function RuasNumeracoesPage(): JSX.Element {
                     <td>{streets.find(s => s.id === a.streetId)?.name}</td>
                     <td>{a.numberStart}</td>
                     <td>{a.numberEnd}</td>
+                    <td>{propertyTypes.find(pt => pt.id === a.propertyTypeId)?.name}</td>
                   </tr>
                 ))}
               </tbody>
@@ -229,4 +243,4 @@ function ImageAnnotator(props: ImageAnnotatorProps): JSX.Element {
       )}
     </div>
   );
-
+}

--- a/src/types/address.ts
+++ b/src/types/address.ts
@@ -3,5 +3,6 @@ export interface Address {
   streetId: number;
   numberStart: number;
   numberEnd: number;
+  propertyTypeId: number;
 }
 

--- a/src/types/territorio.ts
+++ b/src/types/territorio.ts
@@ -2,4 +2,5 @@ export interface Territorio {
   id: string;
   nome: string;
   imagem?: string;
+  imageUrl?: string;
 }


### PR DESCRIPTION
## Summary
- coerce numeric fields in address schema and form
- add property type selection and display
- include optional image URL for territories

## Testing
- `npm test -- --run`
- `npm run lint` *(fails: 'React' must be in scope when using JSX)*

------
https://chatgpt.com/codex/tasks/task_e_68c32af1a7f48325ac50e11b76e5f1fc