### PR TITLE
Add buildings villages repository

### DIFF
--- a/src/services/repositories/buildings_villages.ts
+++ b/src/services/repositories/buildings_villages.ts
@@ -1,0 +1,17 @@
+import type { BuildingVillage } from '../../types/building_village';
+import { db } from '../db';
+
+export const BuildingVillageRepository = {
+  async all(): Promise<BuildingVillage[]> {
+    return db.buildingsVillages.toArray();
+  },
+  async add(buildingVillage: BuildingVillage): Promise<void> {
+    await db.buildingsVillages.put(buildingVillage);
+  },
+  async bulkAdd(buildingsVillages: BuildingVillage[]): Promise<void> {
+    await db.buildingsVillages.bulkPut(buildingsVillages);
+  },
+  async remove(id: string): Promise<void> {
+    await db.buildingsVillages.delete(id);
+  }
+};

--- a/src/services/repositories/index.ts
+++ b/src/services/repositories/index.ts
@@ -2,3 +2,4 @@ export * from './territorios';
 export * from './saidas';
 export * from './designacoes';
 export * from './sugestoes';
+export * from './buildings_villages';


### PR DESCRIPTION
## Summary
- add a repository module for working with buildingsVillages records
- export the new repository from the repositories index barrel

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c854b4d0448325acc0a74a6acd3a8a