### PR TITLE
Add buildings and villages sidebar item

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -46,9 +46,21 @@ const SuggestIcon = () => (
   </svg>
 );
 
+const BuildingIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M3 21h18" />
+    <path d="M6 21V9h6v12" />
+    <path d="M12 21V5h6v16" />
+    <path d="M9 13h2" />
+    <path d="M15 9h2" />
+    <path d="M15 13h2" />
+  </svg>
+);
+
 const items = [
   { id: 'territories', label: 'sidebar.territories', icon: <MapIcon /> },
   { id: 'streets', label: 'sidebar.streets', icon: <MapIcon /> },
+  { id: 'buildingsVillages', label: 'sidebar.buildingsVillages', icon: <BuildingIcon /> },
   { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
   { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
   { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -23,6 +23,7 @@
   "sidebar": {
     "territories": "Territories",
     "streets": "Streets",
+    "buildingsVillages": "Buildings & Villages",
     "exits": "Exits",
     "assignments": "Assignments",
     "calendar": "Calendar",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -23,6 +23,7 @@
   "sidebar": {
     "territories": "Territórios",
     "streets": "Ruas",
+    "buildingsVillages": "Prédios e Vilas",
     "exits": "Saídas",
     "assignments": "Designações",
     "calendar": "Calendário",


### PR DESCRIPTION
## Summary
- add a Buildings & Villages navigation item to the sidebar with a custom icon
- provide English and Portuguese translations for the new sidebar label

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c8588abdb88325aaa61e616aa58197