### PR TITLE
Align ImageAnnotator callbacks with usage

### DIFF
--- a/src/components/ImageAnnotator.test.tsx
+++ b/src/components/ImageAnnotator.test.tsx
@@ -1,0 +1,96 @@
+import { act } from 'react';
+import type { ComponentProps } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import { createRoot } from 'react-dom/client';
+import ImageAnnotator from './ImageAnnotator';
+
+// Inform React that the environment supports `act`
+// See https://react.dev/reference/test-utils/act#setting-up-your-test-environment
+// Vitest + jsdom does not set this flag automatically.
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const renderAnnotator = (
+  props: Partial<Omit<ComponentProps<typeof ImageAnnotator>, 'imageUrl'>> = {}
+) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(<ImageAnnotator imageUrl="/test.png" {...props} />);
+  });
+
+  const canvas = container.querySelector('canvas');
+  if (!canvas) throw new Error('Canvas element not found');
+
+  const cleanup = (): void => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { canvas, cleanup };
+};
+
+describe('ImageAnnotator', () => {
+  it('calls onAdd and onUpdate with the correct coordinates', () => {
+    const onAdd = vi.fn();
+    const onUpdate = vi.fn();
+
+    const { canvas, cleanup } = renderAnnotator({ onAdd, onUpdate });
+
+    const rectSpy = vi
+      .spyOn(canvas, 'getBoundingClientRect')
+      .mockReturnValue(new DOMRect(10, 20, 200, 100));
+
+    act(() => {
+      canvas.dispatchEvent(
+        new MouseEvent('click', { bubbles: true, clientX: 30, clientY: 70, button: 0 })
+      );
+    });
+
+    expect(onAdd).toHaveBeenCalledTimes(1);
+    expect(onAdd).toHaveBeenCalledWith({ x: 20, y: 50 });
+
+    act(() => {
+      canvas.dispatchEvent(
+        new MouseEvent('contextmenu', {
+          bubbles: true,
+          clientX: 60,
+          clientY: 90,
+          button: 2
+        })
+      );
+    });
+
+    expect(onUpdate).toHaveBeenCalledTimes(1);
+    expect(onUpdate).toHaveBeenCalledWith({ x: 50, y: 70 });
+
+    rectSpy.mockRestore();
+    cleanup();
+  });
+
+  it('calls onDelete on double click', () => {
+    const onDelete = vi.fn();
+
+    const { canvas, cleanup } = renderAnnotator({ onDelete });
+
+    const rectSpy = vi
+      .spyOn(canvas, 'getBoundingClientRect')
+      .mockReturnValue(new DOMRect(5, 5, 100, 100));
+
+    act(() => {
+      canvas.dispatchEvent(
+        new MouseEvent('dblclick', { bubbles: true, clientX: 25, clientY: 45, detail: 2 })
+      );
+    });
+
+    expect(onDelete).toHaveBeenCalledTimes(1);
+    expect(onDelete).toHaveBeenCalledWith({ x: 20, y: 40 });
+
+    rectSpy.mockRestore();
+    cleanup();
+  });
+});
+

--- a/src/components/ImageAnnotator.tsx
+++ b/src/components/ImageAnnotator.tsx
@@ -2,24 +2,34 @@ import React from 'react';
 
 export interface ImageAnnotatorProps {
   imageUrl: string;
-  onAddStreet: (point: { x: number; y: number }) => void;
-  onAddAddress: (point: { x: number; y: number }) => void;
+  onAdd?: (point: { x: number; y: number }) => void | Promise<void>;
+  onUpdate?: (point: { x: number; y: number }) => void | Promise<void>;
+  onDelete?: (point: { x: number; y: number }) => void | Promise<void>;
 }
 
-export default function ImageAnnotator({ imageUrl, onAddStreet, onAddAddress }: ImageAnnotatorProps): JSX.Element {
-  const handleClick = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    onAddStreet({ x, y });
+const getPoint = (event: React.MouseEvent<HTMLCanvasElement>): { x: number; y: number } => {
+  const rect = event.currentTarget.getBoundingClientRect();
+  return {
+    x: event.clientX - rect.left,
+    y: event.clientY - rect.top
+  };
+};
+
+export default function ImageAnnotator({ imageUrl, onAdd, onUpdate, onDelete }: ImageAnnotatorProps): JSX.Element {
+  const handleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    const point = getPoint(event);
+    void onAdd?.(point);
   };
 
-  const handleContextMenu = (e: React.MouseEvent<HTMLCanvasElement>) => {
-    e.preventDefault();
-    const rect = e.currentTarget.getBoundingClientRect();
-    const x = e.clientX - rect.left;
-    const y = e.clientY - rect.top;
-    onAddAddress({ x, y });
+  const handleContextMenu = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    event.preventDefault();
+    const point = getPoint(event);
+    void onUpdate?.(point);
+  };
+
+  const handleDoubleClick = (event: React.MouseEvent<HTMLCanvasElement>) => {
+    const point = getPoint(event);
+    void onDelete?.(point);
   };
 
   return (
@@ -29,6 +39,7 @@ export default function ImageAnnotator({ imageUrl, onAddStreet, onAddAddress }: 
         className="absolute top-0 left-0 w-full h-full cursor-crosshair"
         onClick={handleClick}
         onContextMenu={handleContextMenu}
+        onDoubleClick={handleDoubleClick}
       />
     </div>
   );

--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -79,14 +79,20 @@ export default function RuasNumeracoesPage(): JSX.Element {
     form.reset();
   };
 
-  const handleAddAddress = async (addr: Address): Promise<void> => {
-    await db.addresses.put(addr);
-    setAddresses(await db.addresses.toArray());
+  const focusAddressesTab = (): void => {
+    setActiveTab('enderecos');
   };
 
-  const handleDeleteAddress = async (id: number): Promise<void> => {
-    await db.addresses.delete(id);
-    setAddresses(await db.addresses.toArray());
+  const handleAnnotatorAdd = (_point: { x: number; y: number }): void => {
+    focusAddressesTab();
+  };
+
+  const handleAnnotatorUpdate = (_point: { x: number; y: number }): void => {
+    focusAddressesTab();
+  };
+
+  const handleAnnotatorDelete = (_point: { x: number; y: number }): void => {
+    focusAddressesTab();
   };
 
   return (
@@ -95,9 +101,9 @@ export default function RuasNumeracoesPage(): JSX.Element {
         {territory && (
           <ImageAnnotator
             imageUrl={territory.imageUrl ?? territory.imagem ?? ''}
-            onAdd={handleAddAddress}
-            onUpdate={handleAddAddress}
-            onDelete={handleDeleteAddress}
+            onAdd={handleAnnotatorAdd}
+            onUpdate={handleAnnotatorUpdate}
+            onDelete={handleAnnotatorDelete}
           />
         )}
       </div>
@@ -221,27 +227,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
           </div>
         )}
       </div>
-    </div>
-  );
-}
-
-// placeholder to satisfy TypeScript when component is missing
-interface ImageAnnotatorProps {
-  imageUrl: string;
-  onAdd?: (a: Address) => void;
-  onUpdate?: (a: Address) => void;
-  onDelete?: (id: number) => void;
-}
-
-function PlaceholderImageAnnotator(props: ImageAnnotatorProps): JSX.Element {
-  return (
-    <div className="w-full h-full grid place-items-center bg-neutral-100 text-sm">
-      {/* Placeholder component - actual implementation should annotate the image */}
-      {props.imageUrl ? (
-        <img src={props.imageUrl} alt="territory" className="max-w-full" />
-      ) : (
-        <span>Sem imagem</span>
-      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- update the ImageAnnotator component to expose generic onAdd/onUpdate/onDelete callbacks and support double-click deletion events
- adapt RuasNumeracoesPage to focus the address tab when annotation callbacks fire and remove the placeholder implementation
- add unit tests that simulate left, right, and double clicks to ensure callbacks receive the expected coordinates

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c867f825e08325904a8f55b4699607