### PR TITLE
Add tests for utility helpers

### DIFF
--- a/src/utils/dates.test.ts
+++ b/src/utils/dates.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, test } from 'vitest';
+import { addDays, formatDate } from './dates';
+
+describe('dates utils', () => {
+  test('formatDate returns ISO string representation', () => {
+    const date = new Date('2024-02-29T12:00:00Z');
+    expect(formatDate(date)).toBe('2024-02-29');
+  });
+
+  test('addDays handles transitions across months and years', () => {
+    expect(addDays('2023-12-31', 1)).toBe('2024-01-01');
+    expect(addDays('2024-01-31', 1)).toBe('2024-02-01');
+  });
+});

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('../i18n', () => ({
+  default: { language: 'en-US' }
+}));
+
+describe('format utils', () => {
+  test('formatDate respects the configured language', async () => {
+    const { formatDate } = await import('./format');
+    const i18n = (await import('../i18n')).default as { language: string };
+    const date = new Date('2024-05-10T12:00:00Z');
+
+    i18n.language = 'en-US';
+    const enUsResult = formatDate(date);
+    expect(enUsResult).toBe(new Intl.DateTimeFormat('en-US').format(date));
+
+    i18n.language = 'pt-BR';
+    const ptBrResult = formatDate(date);
+    expect(ptBrResult).toBe(new Intl.DateTimeFormat('pt-BR').format(date));
+    expect(ptBrResult).not.toBe(enUsResult);
+  });
+
+  test('formatNumber formats numbers according to language', async () => {
+    const { formatNumber } = await import('./format');
+    const i18n = (await import('../i18n')).default as { language: string };
+    const value = 1234.56;
+
+    i18n.language = 'en-US';
+    const enUsResult = formatNumber(value);
+    expect(enUsResult).toBe(new Intl.NumberFormat('en-US').format(value));
+
+    i18n.language = 'pt-BR';
+    const ptBrResult = formatNumber(value);
+    expect(ptBrResult).toBe(new Intl.NumberFormat('pt-BR').format(value));
+    expect(ptBrResult).not.toBe(enUsResult);
+  });
+});

--- a/src/utils/guards.test.ts
+++ b/src/utils/guards.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, test } from 'vitest';
+import { isDefined } from './guards';
+
+describe('guards utils', () => {
+  test('isDefined filters out null and undefined values', () => {
+    const values = [1, null, 2, undefined, 3, 0];
+    const filtered = values.filter(isDefined);
+    expect(filtered).toEqual([1, 2, 3, 0]);
+  });
+});

--- a/src/utils/score.test.ts
+++ b/src/utils/score.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, test } from 'vitest';
+import { computeScore } from './score';
+
+describe('score utils', () => {
+  test('computeScore sums the provided values', () => {
+    expect(computeScore([1, 2, 3, 4])).toBe(10);
+    expect(computeScore([5, -2, 7])).toBe(10);
+  });
+
+  test('computeScore returns zero for an empty array', () => {
+    expect(computeScore([])).toBe(0);
+  });
+});

--- a/src/utils/storage.test.ts
+++ b/src/utils/storage.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { load, save } from './storage';
+
+type LocalStorageMock = {
+  localStorageMock: Storage;
+  getItem: ReturnType<typeof vi.fn>;
+  setItem: ReturnType<typeof vi.fn>;
+};
+
+const createLocalStorageMock = (): LocalStorageMock => {
+  const store = new Map<string, string>();
+  const getItem = vi.fn((key: string) => (store.has(key) ? store.get(key)! : null));
+  const setItem = vi.fn((key: string, value: string) => {
+    store.set(key, value);
+  });
+  const removeItem = vi.fn((key: string) => {
+    store.delete(key);
+  });
+  const clear = vi.fn(() => {
+    store.clear();
+  });
+  const key = vi.fn((index: number) => Array.from(store.keys())[index] ?? null);
+  const localStorageMock = {
+    getItem,
+    setItem,
+    removeItem,
+    clear,
+    key,
+  };
+  Object.defineProperty(localStorageMock, 'length', {
+    get: () => store.size,
+  });
+  return {
+    localStorageMock: localStorageMock as unknown as Storage,
+    getItem,
+    setItem,
+  };
+};
+
+describe('storage utils', () => {
+  let storageMock: LocalStorageMock;
+
+  beforeEach(() => {
+    storageMock = createLocalStorageMock();
+    vi.stubGlobal('localStorage', storageMock.localStorageMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('save stores serialized values and load returns parsed data', () => {
+    const payload = { id: 1, name: 'Ana' };
+
+    save('user', payload);
+    expect(storageMock.setItem).toHaveBeenCalledWith('user', JSON.stringify(payload));
+
+    const loaded = load<typeof payload>('user');
+    expect(loaded).toEqual(payload);
+  });
+
+  test('load returns null when the key does not exist', () => {
+    const result = load('missing');
+    expect(result).toBeNull();
+    expect(storageMock.getItem).toHaveBeenCalledWith('missing');
+  });
+});


### PR DESCRIPTION
## Summary
- add coverage for date formatting and day addition rollovers
- verify format, guard, score, and storage utilities with localized and mocked dependencies

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c86b2d97d08325bd2c8e524c9ff026