### PR TITLE
Add tests for confirm dialog, toast notifications, and language selector

### DIFF
--- a/src/components/feedback/ConfirmDialog.test.tsx
+++ b/src/components/feedback/ConfirmDialog.test.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({ t: (key: string) => key }),
+}));
+
+import { ConfirmProvider, useConfirm } from './ConfirmDialog';
+
+type ResolveHandler = (value: boolean) => void;
+
+const TestComponent: React.FC<{ message: string; onResolved: ResolveHandler }> = ({
+  message,
+  onResolved,
+}) => {
+  const confirm = useConfirm();
+
+  return (
+    <button
+      data-testid="trigger"
+      onClick={() => {
+        void confirm(message).then(onResolved);
+      }}
+    >
+      trigger
+    </button>
+  );
+};
+
+const renderConfirm = (message: string, onResolved: ResolveHandler) => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <ConfirmProvider>
+        <TestComponent message={message} onResolved={onResolved} />
+      </ConfirmProvider>
+    );
+  });
+
+  const trigger = container.querySelector<HTMLButtonElement>('button[data-testid="trigger"]');
+  if (!trigger) throw new Error('Trigger button not found');
+
+  const cleanup = () => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { container, trigger, cleanup };
+};
+
+describe('ConfirmDialog', () => {
+  it('resolves to true when confirmation button is clicked', async () => {
+    const message = 'Delete this item?';
+    let resolvePromise: ResolveHandler = () => {};
+    const resultPromise = new Promise<boolean>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const onResolved = vi.fn((value: boolean) => {
+      resolvePromise(value);
+    });
+
+    const { container, trigger, cleanup } = renderConfirm(message, onResolved);
+
+    try {
+      await act(async () => {
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(container.textContent).toContain(message);
+
+      const confirmButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+        btn.textContent?.includes('confirm.confirm')
+      );
+      if (!confirmButton) throw new Error('Confirm button not found');
+
+      await act(async () => {
+        confirmButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      const result = await resultPromise;
+
+      expect(result).toBe(true);
+      expect(onResolved).toHaveBeenCalledWith(true);
+      expect(container.textContent).not.toContain(message);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('resolves to false when cancellation button is clicked', async () => {
+    const message = 'Cancel this action?';
+    let resolvePromise: ResolveHandler = () => {};
+    const resultPromise = new Promise<boolean>((resolve) => {
+      resolvePromise = resolve;
+    });
+    const onResolved = vi.fn((value: boolean) => {
+      resolvePromise(value);
+    });
+
+    const { container, trigger, cleanup } = renderConfirm(message, onResolved);
+
+    try {
+      await act(async () => {
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      expect(container.textContent).toContain(message);
+
+      const cancelButton = Array.from(container.querySelectorAll('button')).find((btn) =>
+        btn.textContent?.includes('confirm.cancel')
+      );
+      if (!cancelButton) throw new Error('Cancel button not found');
+
+      await act(async () => {
+        cancelButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      const result = await resultPromise;
+
+      expect(result).toBe(false);
+      expect(onResolved).toHaveBeenCalledWith(false);
+      expect(container.textContent).not.toContain(message);
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/src/components/feedback/Toast.test.tsx
+++ b/src/components/feedback/Toast.test.tsx
@@ -1,0 +1,109 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ToastProvider, useToast } from './Toast';
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const Buttons: React.FC = () => {
+  const toast = useToast();
+
+  return (
+    <div>
+      <button data-testid="success" onClick={() => toast.success('All good!')}>
+        success
+      </button>
+      <button data-testid="error" onClick={() => toast.error('Something went wrong!')}>
+        error
+      </button>
+    </div>
+  );
+};
+
+const renderToasts = () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(
+      <ToastProvider>
+        <Buttons />
+      </ToastProvider>
+    );
+  });
+
+  const getButton = (testId: string) =>
+    container.querySelector<HTMLButtonElement>(`button[data-testid="${testId}"]`);
+
+  const cleanup = () => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { container, getButton, cleanup };
+};
+
+describe('ToastProvider', () => {
+  it('displays and removes a success toast after the timeout', async () => {
+    vi.useFakeTimers();
+    const { container, getButton, cleanup } = renderToasts();
+
+    try {
+      const trigger = getButton('success');
+      if (!trigger) throw new Error('Success trigger not found');
+
+      await act(async () => {
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      const toast = container.querySelector('.bg-green-600');
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toBe('All good!');
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(container.querySelector('.bg-green-600')).toBeNull();
+      expect(container.textContent).not.toContain('All good!');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+      cleanup();
+    }
+  });
+
+  it('displays and removes an error toast after the timeout', async () => {
+    vi.useFakeTimers();
+    const { container, getButton, cleanup } = renderToasts();
+
+    try {
+      const trigger = getButton('error');
+      if (!trigger) throw new Error('Error trigger not found');
+
+      await act(async () => {
+        trigger.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      });
+
+      const toast = container.querySelector('.bg-red-600');
+      expect(toast).not.toBeNull();
+      expect(toast?.textContent).toBe('Something went wrong!');
+
+      await act(async () => {
+        vi.advanceTimersByTime(3000);
+      });
+
+      expect(container.querySelector('.bg-red-600')).toBeNull();
+      expect(container.textContent).not.toContain('Something went wrong!');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+      cleanup();
+    }
+  });
+});

--- a/src/components/forms/LanguageSelector.test.tsx
+++ b/src/components/forms/LanguageSelector.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { act } from 'react';
+import { createRoot } from 'react-dom/client';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type MockI18n = {
+  language: string;
+  changeLanguage: (lng: string) => void;
+};
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true;
+
+const changeLanguageSpy = vi.fn<(lng: string) => void>();
+const mockI18n: MockI18n = {
+  language: 'en-US',
+  changeLanguage: (lng: string) => {
+    mockI18n.language = lng;
+    changeLanguageSpy(lng);
+  },
+};
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+    i18n: mockI18n,
+  }),
+}));
+
+import { LanguageSelector } from './LanguageSelector';
+
+const renderSelector = () => {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(<LanguageSelector />);
+  });
+
+  const cleanup = () => {
+    act(() => {
+      root.unmount();
+    });
+    container.remove();
+  };
+
+  return { container, root, cleanup };
+};
+
+describe('LanguageSelector', () => {
+  beforeEach(() => {
+    mockI18n.language = 'en-US';
+    changeLanguageSpy.mockClear();
+    localStorage.clear();
+  });
+
+  it('changes the language and stores the selection', async () => {
+    const { container, root, cleanup } = renderSelector();
+
+    try {
+      const select = container.querySelector('select');
+      if (!select) throw new Error('Language selector not found');
+
+      await act(async () => {
+        select.value = 'pt-BR';
+        select.dispatchEvent(new Event('change', { bubbles: true }));
+      });
+
+      expect(changeLanguageSpy).toHaveBeenCalledWith('pt-BR');
+      expect(localStorage.getItem('locale')).toBe('pt-BR');
+
+      await act(async () => {
+        root.render(<LanguageSelector />);
+      });
+
+      const updatedSelect = container.querySelector('select');
+      expect(updatedSelect?.value).toBe('pt-BR');
+    } finally {
+      cleanup();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add ConfirmDialog tests to exercise confirmation and cancellation resolution
- add ToastProvider tests to cover success/error display and timed removal
- add LanguageSelector tests to ensure language changes invoke i18n and persist

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c873e2c0b483258c3e542a08da73a8