### PR TITLE
Add coverage for reducer and context hooks

### DIFF
--- a/src/hooks/contextHooks.test.ts
+++ b/src/hooks/contextHooks.test.ts
@@ -1,0 +1,263 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('react', async () => {
+  const actual = await vi.importActual<typeof import('react')>('react');
+  return {
+    ...actual,
+    useContext: vi.fn(),
+  };
+});
+
+import { useContext } from 'react';
+import { AppContext } from '../store/AppProvider';
+import type { AppState, Action } from '../store/appReducer';
+import type { Territorio } from '../types/territorio';
+import type { Saida } from '../types/saida';
+import type { Designacao } from '../types/designacao';
+import type { Sugestao } from '../types/sugestao';
+import * as selectors from '../store/selectors';
+import { useApp } from './useApp';
+import { useTerritorios } from './useTerritorios';
+import { useSaidas } from './useSaidas';
+import { useDesignacoes } from './useDesignacoes';
+import { useSugestoes } from './useSugestoes';
+
+const mockedUseContext = useContext as unknown as ReturnType<typeof vi.fn>;
+
+const createAppState = (): AppState => ({
+  territorios: [
+    {
+      id: 'territorio-1',
+      nome: 'Território 1',
+    },
+  ],
+  saidas: [
+    {
+      id: 'saida-1',
+      nome: 'Saída 1',
+      diaDaSemana: 1,
+      hora: '08:00',
+    },
+  ],
+  designacoes: [
+    {
+      id: 'designacao-1',
+      territorioId: 'territorio-1',
+      saidaId: 'saida-1',
+      dataInicial: '2024-01-01',
+      dataFinal: '2024-01-07',
+    },
+  ],
+  sugestoes: [
+    {
+      territorioId: 'territorio-1',
+      saidaId: 'saida-1',
+      dataInicial: '2024-02-01',
+      dataFinal: '2024-02-07',
+    },
+  ],
+});
+
+const setupContext = () => {
+  const state = createAppState();
+  const dispatch = vi.fn<[Action], void>();
+  const contextValue = { state, dispatch };
+  mockedUseContext.mockReturnValue(contextValue);
+  return { state, dispatch, contextValue };
+};
+
+beforeEach(() => {
+  mockedUseContext.mockReset();
+});
+
+describe('App context hooks', () => {
+  describe('useApp', () => {
+    it('returns the AppContext value', () => {
+      const { contextValue } = setupContext();
+
+      const result = useApp();
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(result).toBe(contextValue);
+    });
+  });
+
+  describe('useTerritorios', () => {
+    it('selects territorios from the current state', () => {
+      const { state } = setupContext();
+      const selected: Territorio[] = [
+        { id: 'territorio-2', nome: 'Outro Território' },
+      ];
+      const selectSpy = vi
+        .spyOn(selectors, 'selectTerritorios')
+        .mockReturnValue(selected);
+
+      const { territorios } = useTerritorios();
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(selectSpy).toHaveBeenCalledWith(state);
+      expect(territorios).toBe(selected);
+
+      selectSpy.mockRestore();
+    });
+
+    it('dispatches an action to add a território', () => {
+      const { dispatch, state } = setupContext();
+      const newTerritorio: Territorio = {
+        id: 'territorio-2',
+        nome: 'Novo Território',
+      };
+      const selectSpy = vi
+        .spyOn(selectors, 'selectTerritorios')
+        .mockReturnValue(state.territorios);
+
+      const { addTerritorio } = useTerritorios();
+      addTerritorio(newTerritorio);
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'ADD_TERRITORIO',
+        payload: newTerritorio,
+      });
+
+      selectSpy.mockRestore();
+    });
+  });
+
+  describe('useSaidas', () => {
+    it('selects saidas from the current state', () => {
+      const { state } = setupContext();
+      const selected: Saida[] = [
+        { id: 'saida-2', nome: 'Outra Saída', diaDaSemana: 2, hora: '09:00' },
+      ];
+      const selectSpy = vi.spyOn(selectors, 'selectSaidas').mockReturnValue(selected);
+
+      const { saidas } = useSaidas();
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(selectSpy).toHaveBeenCalledWith(state);
+      expect(saidas).toBe(selected);
+
+      selectSpy.mockRestore();
+    });
+
+    it('dispatches an action to add a saída', () => {
+      const { dispatch, state } = setupContext();
+      const newSaida: Saida = {
+        id: 'saida-2',
+        nome: 'Nova Saída',
+        diaDaSemana: 2,
+        hora: '09:00',
+      };
+      const selectSpy = vi.spyOn(selectors, 'selectSaidas').mockReturnValue(state.saidas);
+
+      const { addSaida } = useSaidas();
+      addSaida(newSaida);
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(dispatch).toHaveBeenCalledWith({ type: 'ADD_SAIDA', payload: newSaida });
+
+      selectSpy.mockRestore();
+    });
+  });
+
+  describe('useDesignacoes', () => {
+    it('selects designacoes from the current state', () => {
+      const { state } = setupContext();
+      const selected: Designacao[] = [
+        {
+          id: 'designacao-2',
+          territorioId: 'territorio-1',
+          saidaId: 'saida-1',
+          dataInicial: '2024-03-01',
+          dataFinal: '2024-03-07',
+        },
+      ];
+      const selectSpy = vi
+        .spyOn(selectors, 'selectDesignacoes')
+        .mockReturnValue(selected);
+
+      const { designacoes } = useDesignacoes();
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(selectSpy).toHaveBeenCalledWith(state);
+      expect(designacoes).toBe(selected);
+
+      selectSpy.mockRestore();
+    });
+
+    it('dispatches an action to add a designação', () => {
+      const { dispatch, state } = setupContext();
+      const newDesignacao: Designacao = {
+        id: 'designacao-2',
+        territorioId: 'territorio-1',
+        saidaId: 'saida-1',
+        dataInicial: '2024-03-01',
+        dataFinal: '2024-03-07',
+      };
+      const selectSpy = vi
+        .spyOn(selectors, 'selectDesignacoes')
+        .mockReturnValue(state.designacoes);
+
+      const { addDesignacao } = useDesignacoes();
+      addDesignacao(newDesignacao);
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'ADD_DESIGNACAO',
+        payload: newDesignacao,
+      });
+
+      selectSpy.mockRestore();
+    });
+  });
+
+  describe('useSugestoes', () => {
+    it('selects sugestoes from the current state', () => {
+      const { state } = setupContext();
+      const selected: Sugestao[] = [
+        {
+          territorioId: 'territorio-1',
+          saidaId: 'saida-1',
+          dataInicial: '2024-04-01',
+          dataFinal: '2024-04-07',
+        },
+      ];
+      const selectSpy = vi
+        .spyOn(selectors, 'selectSugestoes')
+        .mockReturnValue(selected);
+
+      const { sugestoes } = useSugestoes();
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(selectSpy).toHaveBeenCalledWith(state);
+      expect(sugestoes).toBe(selected);
+
+      selectSpy.mockRestore();
+    });
+
+    it('dispatches an action to add a sugestão', () => {
+      const { dispatch, state } = setupContext();
+      const newSugestao: Sugestao = {
+        territorioId: 'territorio-1',
+        saidaId: 'saida-1',
+        dataInicial: '2024-04-01',
+        dataFinal: '2024-04-07',
+      };
+      const selectSpy = vi
+        .spyOn(selectors, 'selectSugestoes')
+        .mockReturnValue(state.sugestoes);
+
+      const { addSugestao } = useSugestoes();
+      addSugestao(newSugestao);
+
+      expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: 'ADD_SUGESTAO',
+        payload: newSugestao,
+      });
+
+      selectSpy.mockRestore();
+    });
+  });
+});

--- a/src/store/appReducer.test.ts
+++ b/src/store/appReducer.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it } from 'vitest';
+import { appReducer, type AppState } from './appReducer';
+import type { Territorio } from '../types/territorio';
+import type { Saida } from '../types/saida';
+import type { Designacao } from '../types/designacao';
+import type { Sugestao } from '../types/sugestao';
+
+const baseTerritorio: Territorio = { id: 'territorio-1', nome: 'Território 1' };
+const baseSaida: Saida = {
+  id: 'saida-1',
+  nome: 'Saída 1',
+  diaDaSemana: 1,
+  hora: '08:00',
+};
+const baseDesignacao: Designacao = {
+  id: 'designacao-1',
+  territorioId: 'territorio-1',
+  saidaId: 'saida-1',
+  dataInicial: '2024-01-01',
+  dataFinal: '2024-01-07',
+};
+const baseSugestao: Sugestao = {
+  territorioId: 'territorio-1',
+  saidaId: 'saida-1',
+  dataInicial: '2024-02-01',
+  dataFinal: '2024-02-07',
+};
+
+const createState = (): AppState => ({
+  territorios: [{ ...baseTerritorio }],
+  saidas: [{ ...baseSaida }],
+  designacoes: [{ ...baseDesignacao }],
+  sugestoes: [{ ...baseSugestao }],
+});
+
+describe('appReducer', () => {
+  it('adds a território without mutating existing state', () => {
+    const state = createState();
+    const originalTerritorios = state.territorios;
+    const newTerritorio: Territorio = { id: 'territorio-2', nome: 'Novo Território' };
+
+    const nextState = appReducer(state, { type: 'ADD_TERRITORIO', payload: newTerritorio });
+
+    expect(nextState).not.toBe(state);
+    expect(nextState.territorios).toEqual([...originalTerritorios, newTerritorio]);
+    expect(nextState.territorios).not.toBe(originalTerritorios);
+    expect(state.territorios).toBe(originalTerritorios);
+    expect(state.territorios).toHaveLength(1);
+    expect(nextState.saidas).toBe(state.saidas);
+    expect(nextState.designacoes).toBe(state.designacoes);
+    expect(nextState.sugestoes).toBe(state.sugestoes);
+  });
+
+  it('adds a saída without mutating existing state', () => {
+    const state = createState();
+    const originalSaidas = state.saidas;
+    const newSaida: Saida = {
+      id: 'saida-2',
+      nome: 'Nova Saída',
+      diaDaSemana: 2,
+      hora: '09:00',
+    };
+
+    const nextState = appReducer(state, { type: 'ADD_SAIDA', payload: newSaida });
+
+    expect(nextState).not.toBe(state);
+    expect(nextState.saidas).toEqual([...originalSaidas, newSaida]);
+    expect(nextState.saidas).not.toBe(originalSaidas);
+    expect(state.saidas).toBe(originalSaidas);
+    expect(state.saidas).toHaveLength(1);
+    expect(nextState.territorios).toBe(state.territorios);
+    expect(nextState.designacoes).toBe(state.designacoes);
+    expect(nextState.sugestoes).toBe(state.sugestoes);
+  });
+
+  it('adds a designação without mutating existing state', () => {
+    const state = createState();
+    const originalDesignacoes = state.designacoes;
+    const newDesignacao: Designacao = {
+      id: 'designacao-2',
+      territorioId: 'territorio-1',
+      saidaId: 'saida-1',
+      dataInicial: '2024-02-01',
+      dataFinal: '2024-02-07',
+    };
+
+    const nextState = appReducer(state, { type: 'ADD_DESIGNACAO', payload: newDesignacao });
+
+    expect(nextState).not.toBe(state);
+    expect(nextState.designacoes).toEqual([...originalDesignacoes, newDesignacao]);
+    expect(nextState.designacoes).not.toBe(originalDesignacoes);
+    expect(state.designacoes).toBe(originalDesignacoes);
+    expect(state.designacoes).toHaveLength(1);
+    expect(nextState.territorios).toBe(state.territorios);
+    expect(nextState.saidas).toBe(state.saidas);
+    expect(nextState.sugestoes).toBe(state.sugestoes);
+  });
+
+  it('adds a sugestão without mutating existing state', () => {
+    const state = createState();
+    const originalSugestoes = state.sugestoes;
+    const newSugestao: Sugestao = {
+      territorioId: 'territorio-1',
+      saidaId: 'saida-1',
+      dataInicial: '2024-03-01',
+      dataFinal: '2024-03-07',
+    };
+
+    const nextState = appReducer(state, { type: 'ADD_SUGESTAO', payload: newSugestao });
+
+    expect(nextState).not.toBe(state);
+    expect(nextState.sugestoes).toEqual([...originalSugestoes, newSugestao]);
+    expect(nextState.sugestoes).not.toBe(originalSugestoes);
+    expect(state.sugestoes).toBe(originalSugestoes);
+    expect(state.sugestoes).toHaveLength(1);
+    expect(nextState.territorios).toBe(state.territorios);
+    expect(nextState.saidas).toBe(state.saidas);
+    expect(nextState.designacoes).toBe(state.designacoes);
+  });
+});


### PR DESCRIPTION
## Summary
- add unit tests covering appReducer actions and immutability
- add context hook tests to validate selectors and dispatched actions

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c8761ed7a083258499d507db88f24e