### PR TITLE
Initialize Dexie schema before rendering

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,6 +6,7 @@ import { AppProvider } from './store/AppProvider';
 import { ToastProvider } from './components/feedback/Toast';
 import { ConfirmProvider } from './components/feedback/ConfirmDialog';
 import i18n from './i18n';
+import { migrate } from './services/db';
 
 if ('serviceWorker' in navigator) {
   let refreshing = false;
@@ -43,15 +44,25 @@ if ('serviceWorker' in navigator) {
   });
 }
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
-  <React.StrictMode>
-    <AppProvider>
-      <ToastProvider>
-        <ConfirmProvider>
-          <App />
-        </ConfirmProvider>
-      </ToastProvider>
-    </AppProvider>
-  </React.StrictMode>
-);
+async function bootstrap(): Promise<void> {
+  try {
+    await migrate();
+  } catch (error) {
+    console.error('Failed to initialize the IndexedDB schema', error);
+  }
+
+  ReactDOM.createRoot(document.getElementById('root')!).render(
+    <React.StrictMode>
+      <AppProvider>
+        <ToastProvider>
+          <ConfirmProvider>
+            <App />
+          </ConfirmProvider>
+        </ToastProvider>
+      </AppProvider>
+    </React.StrictMode>
+  );
+}
+
+void bootstrap();
 


### PR DESCRIPTION
## Summary
- ensure the IndexedDB schema migration runs before React renders so Dexie stores exist
- log initialization failures to help diagnose database startup issues

## Testing
- npm test
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c87d71d2e88325880b1e6b5d02fe49