### PR TITLE
Fix lint issues

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -22,5 +22,8 @@ module.exports = {
     'plugin:@typescript-eslint/recommended',
     'prettier',
   ],
-  rules: {},
+  rules: {
+    'react/react-in-jsx-scope': 'off',
+    'react/prop-types': 'off',
+  },
 };

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -180,9 +180,6 @@ const Input = React.forwardRef<HTMLInputElement, React.InputHTMLAttributes<HTMLI
   )
 );
 Input.displayName = 'Input';
- const Select: React.FC<React.SelectHTMLAttributes<HTMLSelectElement>> = (props) => (
-  <select {...props} className={`w-full rounded-xl border px-3 py-2 bg-white dark:bg-neutral-900 ${props.className||''}`} />
- );
  const Button: React.FC<React.ButtonHTMLAttributes<HTMLButtonElement>> = ({ className='', ...props }) => (
   <button {...props} className={`rounded-xl px-3 py-2 shadow border hover:shadow-md active:scale-[.98] transition ${className}`} />
  );
@@ -534,14 +531,16 @@ function Shell({children, tab, setTab}:{children: React.ReactNode; tab:TabKey; s
               </thead>
               <tbody>
                 {assignments.map(a => {
-                  const status = a.returned ? 'devolvido' : (new Date(a.endDate) < new Date() ? 'atrasado' : 'ativo');
+                  const status: 'devolvido' | 'atrasado' | 'ativo' = a.returned
+                    ? 'devolvido'
+                    : (new Date(a.endDate) < new Date() ? 'atrasado' : 'ativo');
                   return (
                   <tr key={a.id} className="border-b last:border-0">
                     <td className="py-2">{findName(a.territoryId, territories)}</td>
                     <td>{findName(a.fieldExitId, exits)}</td>
                     <td>{fmtDate(a.startDate)}</td>
                     <td>{fmtDate(a.endDate)}</td>
-                    <td><StatusBadge status={status as any} /></td>
+                    <td><StatusBadge status={status} /></td>
                     <td className="text-right flex gap-2 justify-end">
                       <Button onClick={()=>updateAssignment(a.id, { ...a, returned: !a.returned })} className="bg-neutral-100">{a.returned ? 'Reativar' : 'Devolver'}</Button>
                       <Button onClick={async()=>{ if(await confirm('Excluir designação?')) delAssignment(a.id); }} className="bg-red-50 text-red-700">Excluir</Button>

--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -83,15 +83,15 @@ export default function RuasNumeracoesPage(): JSX.Element {
     setActiveTab('enderecos');
   };
 
-  const handleAnnotatorAdd = (_point: { x: number; y: number }): void => {
+  const handleAnnotatorAdd = (): void => {
     focusAddressesTab();
   };
 
-  const handleAnnotatorUpdate = (_point: { x: number; y: number }): void => {
+  const handleAnnotatorUpdate = (): void => {
     focusAddressesTab();
   };
 
-  const handleAnnotatorDelete = (_point: { x: number; y: number }): void => {
+  const handleAnnotatorDelete = (): void => {
     focusAddressesTab();
   };
 

--- a/src/utils/csv.ts
+++ b/src/utils/csv.ts
@@ -46,11 +46,12 @@ export const importCsv = <T>(
   for (let i = headerIndex + 1; i < lines.length; i++) {
     const values = lines[i].split(',');
     const obj: Partial<T> = {};
+    const target = obj as Record<keyof T, unknown>;
     keys.forEach((key, idx) => {
       if (!key) return;
       let value = values[idx] || '';
       value = value.replace(/^"|"$/g, '').replace(/""/g, '"');
-      (obj as any)[key] = value;
+      target[key] = value;
     });
     if (validate) {
       if (validate(obj)) result.push(obj);


### PR DESCRIPTION
## Summary
- disable React lint rules that conflict with the automatic JSX runtime and TypeScript usage
- tidy UI primitives by removing an unused select component and using a typed assignment status
- strengthen CSV import typing and simplify annotator callbacks to satisfy lint rules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c87fe5c3c88325a6c081dc337c8b6f