### PR TITLE
Refactor data management to AppContext with Dexie

### DIFF
--- a/src/hooks/useMonthlyExportScheduler.ts
+++ b/src/hooks/useMonthlyExportScheduler.ts
@@ -65,7 +65,7 @@ export function useMonthlyExportScheduler() {
     const interval = setInterval(async () => {
       if (Date.now() >= config.nextRun) {
         const designacoes = await DesignacaoRepository.all();
-        const summary = monthlySummaryBySaida(designacoes);
+        const summary = monthlySummaryBySaida(designacoes).map((item) => ({ ...item }));
         const csv = exportToCsv(summary, ['saidaId', 'month', 'total']);
         const date = new Date().toISOString().split('T')[0];
         downloadFile(csv, `monthly-summary-${date}.csv`, 'text/csv');

--- a/src/hooks/useSaidas.ts
+++ b/src/hooks/useSaidas.ts
@@ -1,7 +1,10 @@
-import { useContext } from 'react';
-import { AppContext } from '../store/AppProvider';
+import { useCallback } from 'react';
+import { useApp } from './useApp';
 import { selectSaidas } from '../store/selectors';
 import type { Saida } from '../types/saida';
+import { SaidaRepository } from '../services/repositories';
+import { useToast } from '../components/feedback/Toast';
+import { generateId } from '../utils/id';
 
 /**
  * Custom hook for managing Saidas (field service groups).
@@ -9,14 +12,53 @@ import type { Saida } from '../types/saida';
  * @returns An object with the list of Saidas and a function to add a new Saida.
  */
 export const useSaidas = () => {
-  const { state, dispatch } = useContext(AppContext);
+  const { state, dispatch } = useApp();
+  const toast = useToast();
+  const saidas = selectSaidas(state);
+
   return {
     /** The list of all Saidas. */
-    saidas: selectSaidas(state),
+    saidas,
     /**
-     * Adds a new Saida.
-     * @param s The Saida to add.
+     * Adds a new Saida and persists it.
+     * @param saida The Saida to add.
      */
-    addSaida: (s: Saida) => dispatch({ type: 'ADD_SAIDA', payload: s }),
+    addSaida: useCallback(
+      async (saida: Omit<Saida, 'id'>) => {
+        const record: Saida = { id: generateId(), ...saida };
+        await SaidaRepository.add(record);
+        dispatch({ type: 'ADD_SAIDA', payload: record });
+        toast.success('Saída salva');
+        return record;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Updates an existing Saida.
+     * @param id The identifier of the Saida to update.
+     * @param saida Updated Saida data.
+     */
+    updateSaida: useCallback(
+      async (id: string, saida: Omit<Saida, 'id'>) => {
+        const record: Saida = { id, ...saida };
+        await SaidaRepository.add(record);
+        dispatch({ type: 'UPDATE_SAIDA', payload: record });
+        toast.success('Saída atualizada');
+        return record;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Removes a Saida from persistence.
+     * @param id The identifier of the Saida to remove.
+     */
+    removeSaida: useCallback(
+      async (id: string) => {
+        await SaidaRepository.remove(id);
+        dispatch({ type: 'REMOVE_SAIDA', payload: id });
+        toast.success('Saída removida');
+      },
+      [dispatch, toast],
+    ),
   } as const;
 };

--- a/src/hooks/useSugestoes.ts
+++ b/src/hooks/useSugestoes.ts
@@ -1,7 +1,9 @@
-import { useContext } from 'react';
-import { AppContext } from '../store/AppProvider';
+import { useCallback } from 'react';
+import { useApp } from './useApp';
 import { selectSugestoes } from '../store/selectors';
 import type { Sugestao } from '../types/sugestao';
+import { SugestaoRepository } from '../services/repositories';
+import { useToast } from '../components/feedback/Toast';
 
 /**
  * Custom hook for managing suggestions.
@@ -9,14 +11,51 @@ import type { Sugestao } from '../types/sugestao';
  * @returns An object with the list of suggestions and a function to add a new suggestion.
  */
 export const useSugestoes = () => {
-  const { state, dispatch } = useContext(AppContext);
+  const { state, dispatch } = useApp();
+  const toast = useToast();
+  const sugestoes = selectSugestoes(state);
+
   return {
     /** The list of all suggestions. */
-    sugestoes: selectSugestoes(state),
+    sugestoes,
     /**
-     * Adds a new suggestion.
-     * @param s The suggestion to add.
+     * Adds a new suggestion to the repository.
+     * @param sugestao The suggestion to add.
      */
-    addSugestao: (s: Sugestao) => dispatch({ type: 'ADD_SUGESTAO', payload: s }),
+    addSugestao: useCallback(
+      async (sugestao: Sugestao) => {
+        await SugestaoRepository.add(sugestao);
+        dispatch({ type: 'ADD_SUGESTAO', payload: sugestao });
+        toast.success('Sugestão salva');
+        return sugestao;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Updates an existing suggestion.
+     * @param sugestao The suggestion with updated information.
+     */
+    updateSugestao: useCallback(
+      async (sugestao: Sugestao) => {
+        await SugestaoRepository.add(sugestao);
+        dispatch({ type: 'UPDATE_SUGESTAO', payload: sugestao });
+        toast.success('Sugestão atualizada');
+        return sugestao;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Removes a stored suggestion.
+     * @param territorioId The territory identifier.
+     * @param saidaId The saída identifier.
+     */
+    removeSugestao: useCallback(
+      async (territorioId: string, saidaId: string) => {
+        await SugestaoRepository.remove(territorioId, saidaId);
+        dispatch({ type: 'REMOVE_SUGESTAO', payload: { territorioId, saidaId } });
+        toast.success('Sugestão removida');
+      },
+      [dispatch, toast],
+    ),
   } as const;
 };

--- a/src/hooks/useSuggestionRules.ts
+++ b/src/hooks/useSuggestionRules.ts
@@ -1,0 +1,16 @@
+import type { SuggestionRuleConfig } from '../types/suggestion-rule-config';
+import { useLocalStorage } from './useLocalStorage';
+
+const DEFAULT_RULES: SuggestionRuleConfig = {
+  avoidLastAssignments: 5,
+  defaultDurationDays: 30,
+  avoidMonthsPerExit: 6,
+  recentWeight: 1,
+  balanceWeight: 1,
+};
+
+/**
+ * Persists and retrieves the suggestion rule configuration from local storage.
+ * @returns A tuple containing the current rules and an updater function.
+ */
+export const useSuggestionRules = () => useLocalStorage<SuggestionRuleConfig>('tm.rules', DEFAULT_RULES);

--- a/src/hooks/useTerritorios.ts
+++ b/src/hooks/useTerritorios.ts
@@ -1,7 +1,10 @@
-import { useContext } from 'react';
-import { AppContext } from '../store/AppProvider';
+import { useCallback } from 'react';
+import { useApp } from './useApp';
 import { selectTerritorios } from '../store/selectors';
 import type { Territorio } from '../types/territorio';
+import { TerritorioRepository } from '../services/repositories';
+import { useToast } from '../components/feedback/Toast';
+import { generateId } from '../utils/id';
 
 /**
  * Custom hook for managing territories.
@@ -9,14 +12,53 @@ import type { Territorio } from '../types/territorio';
  * @returns An object with the list of territories and a function to add a new territory.
  */
 export const useTerritorios = () => {
-  const { state, dispatch } = useContext(AppContext);
+  const { state, dispatch } = useApp();
+  const toast = useToast();
+  const territorios = selectTerritorios(state);
+
   return {
     /** The list of all territories. */
-    territorios: selectTerritorios(state),
+    territorios,
     /**
-     * Adds a new territory.
-     * @param t The territory to add.
+     * Adds a new territory and persists it to the repository.
+     * @param territorio The territory data to create.
      */
-    addTerritorio: (t: Territorio) => dispatch({ type: 'ADD_TERRITORIO', payload: t }),
+    addTerritorio: useCallback(
+      async (territorio: Omit<Territorio, 'id'>) => {
+        const record: Territorio = { id: generateId(), ...territorio };
+        await TerritorioRepository.add(record);
+        dispatch({ type: 'ADD_TERRITORIO', payload: record });
+        toast.success('Território salvo');
+        return record;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Updates an existing territory.
+     * @param id The identifier of the territory.
+     * @param territorio Updated territory data.
+     */
+    updateTerritorio: useCallback(
+      async (id: string, territorio: Omit<Territorio, 'id'>) => {
+        const record: Territorio = { id, ...territorio };
+        await TerritorioRepository.add(record);
+        dispatch({ type: 'UPDATE_TERRITORIO', payload: record });
+        toast.success('Território atualizado');
+        return record;
+      },
+      [dispatch, toast],
+    ),
+    /**
+     * Removes a territory from the repository.
+     * @param id The identifier of the territory to remove.
+     */
+    removeTerritorio: useCallback(
+      async (id: string) => {
+        await TerritorioRepository.remove(id);
+        dispatch({ type: 'REMOVE_TERRITORIO', payload: id });
+        toast.success('Território removido');
+      },
+      [dispatch, toast],
+    ),
   } as const;
 };

--- a/src/hooks/useWarningDays.ts
+++ b/src/hooks/useWarningDays.ts
@@ -1,0 +1,6 @@
+import { useLocalStorage } from './useLocalStorage';
+
+/**
+ * Stores the number of warning days before highlighting overdue designations.
+ */
+export const useWarningDays = () => useLocalStorage<number>('tm.warningDays', 2);

--- a/src/pages/ExitsPage.tsx
+++ b/src/pages/ExitsPage.tsx
@@ -1,23 +1,23 @@
 import React, { useState } from 'react';
 import { useConfirm } from '../components/feedback/ConfirmDialog';
 import { Card, Button, Input, Label } from '../components/ui';
-import { useStoreContext } from '../store/localStore';
+import { useSaidas } from '../hooks/useSaidas';
 import { weekdays } from '../utils/calendar';
 
 const ExitsPage: React.FC = () => {
-  const { exits, addExit, delExit } = useStoreContext();
+  const { saidas, addSaida, removeSaida } = useSaidas();
   const confirm = useConfirm();
-  const [name, setName] = useState('');
-  const [dayOfWeek, setDayOfWeek] = useState<number>(6);
-  const [time, setTime] = useState('09:00');
+  const [nome, setNome] = useState('');
+  const [diaDaSemana, setDiaDaSemana] = useState<number>(6);
+  const [hora, setHora] = useState('09:00');
 
-  const submit = (event: React.FormEvent) => {
+  const submit = async (event: React.FormEvent) => {
     event.preventDefault();
-    if (!name.trim()) return;
-    addExit({ name: name.trim(), dayOfWeek, time });
-    setName('');
-    setDayOfWeek(6);
-    setTime('09:00');
+    if (!nome.trim()) return;
+    await addSaida({ nome: nome.trim(), diaDaSemana, hora });
+    setNome('');
+    setDiaDaSemana(6);
+    setHora('09:00');
   };
 
   return (
@@ -26,13 +26,13 @@ const ExitsPage: React.FC = () => {
         <form onSubmit={submit} className="grid md:grid-cols-4 gap-3">
           <div className="grid gap-1">
             <Label>Nome</Label>
-            <Input value={name} onChange={(event) => setName(event.target.value)} placeholder="Ex.: Grupo Sábado Manhã" />
+            <Input value={nome} onChange={(event) => setNome(event.target.value)} placeholder="Ex.: Grupo Sábado Manhã" />
           </div>
           <div className="grid gap-1">
             <Label>Dia da Semana</Label>
             <select
-              value={dayOfWeek}
-              onChange={(event) => setDayOfWeek(Number(event.target.value))}
+              value={diaDaSemana}
+              onChange={(event) => setDiaDaSemana(Number(event.target.value))}
               className="w-full rounded-xl border px-3 py-2 bg-white dark:bg-neutral-900"
             >
               {weekdays.map((weekday, index) => (
@@ -44,7 +44,7 @@ const ExitsPage: React.FC = () => {
           </div>
           <div className="grid gap-1">
             <Label>Horário</Label>
-            <Input type="time" value={time} onChange={(event) => setTime(event.target.value)} />
+            <Input type="time" value={hora} onChange={(event) => setHora(event.target.value)} />
           </div>
           <div className="flex items-end justify-end">
             <Button type="submit" className="bg-black text-white">
@@ -54,23 +54,23 @@ const ExitsPage: React.FC = () => {
         </form>
       </Card>
 
-      <Card title={`Saídas (${exits.length})`}>
-        {exits.length === 0 ? (
+      <Card title={`Saídas (${saidas.length})`}>
+        {saidas.length === 0 ? (
           <p className="text-neutral-500">Nenhuma saída cadastrada.</p>
         ) : (
           <div className="grid md:grid-cols-2 gap-3">
-            {exits.map((exit) => (
-              <div key={exit.id} className="rounded-xl border p-3 flex items-center justify-between bg-white dark:bg-neutral-950">
+            {saidas.map((saida) => (
+              <div key={saida.id} className="rounded-xl border p-3 flex items-center justify-between bg-white dark:bg-neutral-950">
                 <div>
-                  <p className="font-semibold">{exit.name}</p>
+                  <p className="font-semibold">{saida.nome}</p>
                   <p className="text-sm text-neutral-600">
-                    {weekdays[exit.dayOfWeek]} · {exit.time}
+                    {weekdays[saida.diaDaSemana]} · {saida.hora}
                   </p>
                 </div>
                 <Button
                   onClick={async () => {
                     if (await confirm('Excluir saída?')) {
-                      delExit(exit.id);
+                      await removeSaida(saida.id);
                     }
                   }}
                   className="bg-red-50 text-red-700"

--- a/src/pages/TerritoriesPage.tsx
+++ b/src/pages/TerritoriesPage.tsx
@@ -4,12 +4,12 @@ import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useConfirm } from '../components/feedback/ConfirmDialog';
 import { Card, Button, ImagePicker, Input, Label } from '../components/ui';
-import { useStoreContext } from '../store/localStore';
-import type { Territory } from '../types/territory';
+import { useTerritorios } from '../hooks/useTerritorios';
+import type { Territorio } from '../types/territorio';
 
 const territorySchema = z.object({
-  name: z.string().min(1, 'Nome obrigatório'),
-  image: z.string().optional(),
+  nome: z.string().min(1, 'Nome obrigatório'),
+  imagem: z.string().optional(),
 });
 
 type TerritoryForm = z.infer<typeof territorySchema>;
@@ -17,12 +17,12 @@ type TerritoryForm = z.infer<typeof territorySchema>;
 const pageSize = 5;
 
 const TerritoriesPage: React.FC = () => {
-  const { territories, addTerritory, delTerritory, updateTerritory } = useStoreContext();
+  const { territorios, addTerritorio, removeTerritorio, updateTerritorio } = useTerritorios();
   const confirm = useConfirm();
 
   const { register, handleSubmit, reset, setValue, watch, formState } = useForm<TerritoryForm>({
     resolver: zodResolver(territorySchema),
-    defaultValues: { name: '', image: undefined },
+    defaultValues: { nome: '', imagem: undefined },
   });
   const { errors } = formState;
 
@@ -31,9 +31,10 @@ const TerritoriesPage: React.FC = () => {
   const [onlyWithImage, setOnlyWithImage] = useState(false);
   const [page, setPage] = useState(1);
 
-  const filtered = territories.filter(
-    (territory) =>
-      territory.name.toLowerCase().includes(search.toLowerCase()) && (!onlyWithImage || Boolean(territory.image)),
+  const filtered = territorios.filter(
+    (territorio) =>
+      territorio.nome.toLowerCase().includes(search.toLowerCase()) &&
+      (!onlyWithImage || Boolean(territorio.imagem || territorio.imageUrl)),
   );
 
   const pageCount = Math.max(1, Math.ceil(filtered.length / pageSize));
@@ -45,19 +46,19 @@ const TerritoriesPage: React.FC = () => {
 
   const paginated = filtered.slice((page - 1) * pageSize, page * pageSize);
 
-  const onSubmit = (data: TerritoryForm) => {
+  const onSubmit = async (data: TerritoryForm) => {
     if (editingId) {
-      updateTerritory(editingId, data);
+      await updateTerritorio(editingId, data);
     } else {
-      addTerritory(data);
+      await addTerritorio(data);
     }
     reset();
     setEditingId(null);
   };
 
-  const startEdit = (territory: Territory) => {
-    setEditingId(territory.id);
-    reset({ name: territory.name, image: territory.image });
+  const startEdit = (territorio: Territorio) => {
+    setEditingId(territorio.id);
+    reset({ nome: territorio.nome, imagem: territorio.imagem ?? territorio.imageUrl });
   };
 
   return (
@@ -66,12 +67,12 @@ const TerritoriesPage: React.FC = () => {
         <form onSubmit={handleSubmit(onSubmit)} className="grid md:grid-cols-3 gap-3">
           <div className="grid gap-1">
             <Label>Nome</Label>
-            <Input {...register('name')} placeholder="Ex.: Território 12 – Centro" />
-            {errors.name && <p className="text-sm text-red-600">{errors.name.message}</p>}
+            <Input {...register('nome')} placeholder="Ex.: Território 12 – Centro" />
+            {errors.nome && <p className="text-sm text-red-600">{errors.nome.message}</p>}
           </div>
           <div className="grid gap-1 md:col-span-2">
             <Label>Imagem (opcional)</Label>
-            <ImagePicker value={watch('image')} onChange={(value) => setValue('image', value)} compress />
+            <ImagePicker value={watch('imagem')} onChange={(value) => setValue('imagem', value)} compress />
           </div>
           <div className="md:col-span-3 flex justify-end gap-2">
             {editingId && (
@@ -133,25 +134,29 @@ const TerritoriesPage: React.FC = () => {
                 </tr>
               </thead>
               <tbody>
-                {paginated.map((territory) => (
-                  <tr key={territory.id} className="border-b last:border-0">
-                    <td className="py-2">{territory.name}</td>
+                {paginated.map((territorio) => (
+                  <tr key={territorio.id} className="border-b last:border-0">
+                    <td className="py-2">{territorio.nome}</td>
                     <td>
-                      {territory.image ? (
-                        <img src={territory.image} alt={territory.name} className="w-16 h-16 object-cover rounded-lg border" />
+                      {territorio.imagem || territorio.imageUrl ? (
+                        <img
+                          src={territorio.imagem || territorio.imageUrl}
+                          alt={territorio.nome}
+                          className="w-16 h-16 object-cover rounded-lg border"
+                        />
                       ) : (
                         '—'
                       )}
                     </td>
                     <td className="py-2 text-right">
                       <div className="flex gap-2 justify-end">
-                        <Button onClick={() => startEdit(territory)} className="bg-neutral-100">
+                        <Button onClick={() => startEdit(territorio)} className="bg-neutral-100">
                           Editar
                         </Button>
                         <Button
                           onClick={async () => {
                             if (await confirm('Excluir território?')) {
-                              delTerritory(territory.id);
+                              await removeTerritorio(territorio.id);
                             }
                           }}
                           className="bg-red-50 text-red-700"

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -41,7 +41,7 @@ class AppDB extends Dexie {
   /** Table for storing Designacao data. */
   designacoes!: Table<Designacao, string>;
   /** Table for storing Sugestao data. */
-  sugestoes!: Table<Sugestao, string>;
+  sugestoes!: Table<Sugestao, [string, string]>;
   /** Table for storing Street data. */
   streets!: Table<Street, number>;
   /** Table for storing PropertyType data. */

--- a/src/services/repositories/designacoes.ts
+++ b/src/services/repositories/designacoes.ts
@@ -32,6 +32,14 @@ export const DesignacaoRepository = {
   },
 
   /**
+   * Removes all designações from the database.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  async clear(): Promise<void> {
+    await db.designacoes.clear();
+  },
+
+  /**
    * Removes a designacao from the database.
    * @param id The ID of the designacao to remove.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/saidas.ts
+++ b/src/services/repositories/saidas.ts
@@ -32,6 +32,14 @@ export const SaidaRepository = {
   },
 
   /**
+   * Removes all saídas from the database.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  async clear(): Promise<void> {
+    await db.saidas.clear();
+  },
+
+  /**
    * Removes a saida from the database.
    * @param id The ID of the saida to remove.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/sugestoes.ts
+++ b/src/services/repositories/sugestoes.ts
@@ -32,6 +32,14 @@ export const SugestaoRepository = {
   },
 
   /**
+   * Removes all sugestões from the database.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  async clear(): Promise<void> {
+    await db.sugestoes.clear();
+  },
+
+  /**
    * Removes a sugestao from the database.
    * @param territorioId The ID of the territorio associated with the sugestao.
    * @param saidaId The ID of the saida associated with the sugestao.

--- a/src/services/repositories/territorios.ts
+++ b/src/services/repositories/territorios.ts
@@ -32,6 +32,14 @@ export const TerritorioRepository = {
   },
 
   /**
+   * Removes all territórios from the database.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  async clear(): Promise<void> {
+    await db.territorios.clear();
+  },
+
+  /**
    * Removes a territorio from the database.
    * @param id The ID of the territorio to remove.
    * @returns A promise that resolves when the operation is complete.

--- a/src/store/AppProvider.tsx
+++ b/src/store/AppProvider.tsx
@@ -1,4 +1,5 @@
-import { createContext, useReducer, Dispatch, ReactNode } from 'react';
+import { createContext, useEffect, useReducer, Dispatch, ReactNode } from 'react';
+import { TerritorioRepository, SaidaRepository, DesignacaoRepository, SugestaoRepository } from '../services/repositories';
 import { appReducer, initialState, AppState, Action } from './appReducer';
 
 export const AppContext = createContext<{ state: AppState; dispatch: Dispatch<Action> }>(
@@ -10,5 +11,33 @@ export const AppContext = createContext<{ state: AppState; dispatch: Dispatch<Ac
 
 export const AppProvider = ({ children }: { children: ReactNode }) => {
   const [state, dispatch] = useReducer(appReducer, initialState);
+
+  useEffect(() => {
+    let active = true;
+    const hydrate = async () => {
+      try {
+        const [territorios, saidas, designacoes, sugestoes] = await Promise.all([
+          TerritorioRepository.all(),
+          SaidaRepository.all(),
+          DesignacaoRepository.all(),
+          SugestaoRepository.all(),
+        ]);
+        if (!active) return;
+        dispatch({ type: 'SET_TERRITORIOS', payload: territorios });
+        dispatch({ type: 'SET_SAIDAS', payload: saidas });
+        dispatch({ type: 'SET_DESIGNACOES', payload: designacoes });
+        dispatch({ type: 'SET_SUGESTOES', payload: sugestoes });
+      } catch (error) {
+        console.error('Falha ao carregar dados iniciais', error);
+      }
+    };
+
+    void hydrate();
+
+    return () => {
+      active = false;
+    };
+  }, []);
+
   return <AppContext.Provider value={{ state, dispatch }}>{children}</AppContext.Provider>;
 };

--- a/src/store/appReducer.test.ts
+++ b/src/store/appReducer.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { appReducer, type AppState } from './appReducer';
+import { appReducer, initialState, type AppState } from './appReducer';
 import type { Territorio } from '../types/territorio';
 import type { Saida } from '../types/saida';
 import type { Designacao } from '../types/designacao';
@@ -116,5 +116,52 @@ describe('appReducer', () => {
     expect(nextState.territorios).toBe(state.territorios);
     expect(nextState.saidas).toBe(state.saidas);
     expect(nextState.designacoes).toBe(state.designacoes);
+  });
+
+  it('sets territorios with SET_TERRITORIOS', () => {
+    const state = createState();
+    const territorios: Territorio[] = [
+      { id: 'territorio-2', nome: 'Outro' },
+      { id: 'territorio-3', nome: 'Mais um' },
+    ];
+
+    const nextState = appReducer(state, { type: 'SET_TERRITORIOS', payload: territorios });
+
+    expect(nextState.territorios).toEqual(territorios);
+    expect(nextState.saidas).toBe(state.saidas);
+  });
+
+  it('updates a designacao preserving other entries', () => {
+    const state = createState();
+    const updated: Designacao = {
+      ...state.designacoes[0],
+      dataFinal: '2024-02-15',
+      devolvido: true,
+    };
+
+    const nextState = appReducer(state, { type: 'UPDATE_DESIGNACAO', payload: updated });
+
+    expect(nextState.designacoes[0]).toEqual(updated);
+    expect(nextState.designacoes).toHaveLength(state.designacoes.length);
+  });
+
+  it('removes a saida with REMOVE_SAIDA', () => {
+    const state = createState();
+
+    const nextState = appReducer(state, { type: 'REMOVE_SAIDA', payload: 'saida-1' });
+
+    expect(nextState.saidas).toHaveLength(0);
+  });
+
+  it('resets state with RESET_STATE', () => {
+    const state = createState();
+    const populated = appReducer(state, {
+      type: 'ADD_TERRITORIO',
+      payload: { id: 'territorio-99', nome: 'Temporário' },
+    });
+
+    const nextState = appReducer(populated, { type: 'RESET_STATE' });
+
+    expect(nextState).toEqual(initialState);
   });
 });

--- a/src/store/appReducer.ts
+++ b/src/store/appReducer.ts
@@ -18,21 +18,86 @@ export const initialState: AppState = {
 };
 
 export type Action =
+  | { type: 'SET_TERRITORIOS'; payload: Territorio[] }
   | { type: 'ADD_TERRITORIO'; payload: Territorio }
+  | { type: 'UPDATE_TERRITORIO'; payload: Territorio }
+  | { type: 'REMOVE_TERRITORIO'; payload: string }
+  | { type: 'SET_SAIDAS'; payload: Saida[] }
   | { type: 'ADD_SAIDA'; payload: Saida }
+  | { type: 'UPDATE_SAIDA'; payload: Saida }
+  | { type: 'REMOVE_SAIDA'; payload: string }
+  | { type: 'SET_DESIGNACOES'; payload: Designacao[] }
   | { type: 'ADD_DESIGNACAO'; payload: Designacao }
-  | { type: 'ADD_SUGESTAO'; payload: Sugestao };
+  | { type: 'UPDATE_DESIGNACAO'; payload: Designacao }
+  | { type: 'REMOVE_DESIGNACAO'; payload: string }
+  | { type: 'SET_SUGESTOES'; payload: Sugestao[] }
+  | { type: 'ADD_SUGESTAO'; payload: Sugestao }
+  | { type: 'UPDATE_SUGESTAO'; payload: Sugestao }
+  | { type: 'REMOVE_SUGESTAO'; payload: { territorioId: string; saidaId: string } }
+  | { type: 'RESET_STATE' };
 
 export function appReducer(state: AppState, action: Action): AppState {
   switch (action.type) {
+    case 'SET_TERRITORIOS':
+      return { ...state, territorios: [...action.payload] };
     case 'ADD_TERRITORIO':
       return { ...state, territorios: [...state.territorios, action.payload] };
+    case 'UPDATE_TERRITORIO':
+      return {
+        ...state,
+        territorios: state.territorios.map((territorio) =>
+          territorio.id === action.payload.id ? action.payload : territorio,
+        ),
+      };
+    case 'REMOVE_TERRITORIO':
+      return { ...state, territorios: state.territorios.filter((territorio) => territorio.id !== action.payload) };
+    case 'SET_SAIDAS':
+      return { ...state, saidas: [...action.payload] };
     case 'ADD_SAIDA':
       return { ...state, saidas: [...state.saidas, action.payload] };
+    case 'UPDATE_SAIDA':
+      return {
+        ...state,
+        saidas: state.saidas.map((saida) => (saida.id === action.payload.id ? action.payload : saida)),
+      };
+    case 'REMOVE_SAIDA':
+      return { ...state, saidas: state.saidas.filter((saida) => saida.id !== action.payload) };
+    case 'SET_DESIGNACOES':
+      return { ...state, designacoes: [...action.payload] };
     case 'ADD_DESIGNACAO':
       return { ...state, designacoes: [...state.designacoes, action.payload] };
+    case 'UPDATE_DESIGNACAO':
+      return {
+        ...state,
+        designacoes: state.designacoes.map((designacao) =>
+          designacao.id === action.payload.id ? action.payload : designacao,
+        ),
+      };
+    case 'REMOVE_DESIGNACAO':
+      return { ...state, designacoes: state.designacoes.filter((designacao) => designacao.id !== action.payload) };
+    case 'SET_SUGESTOES':
+      return { ...state, sugestoes: [...action.payload] };
     case 'ADD_SUGESTAO':
       return { ...state, sugestoes: [...state.sugestoes, action.payload] };
+    case 'UPDATE_SUGESTAO':
+      return {
+        ...state,
+        sugestoes: state.sugestoes.map((sugestao) =>
+          sugestao.territorioId === action.payload.territorioId && sugestao.saidaId === action.payload.saidaId
+            ? action.payload
+            : sugestao,
+        ),
+      };
+    case 'REMOVE_SUGESTAO':
+      return {
+        ...state,
+        sugestoes: state.sugestoes.filter(
+          (sugestao) =>
+            sugestao.territorioId !== action.payload.territorioId || sugestao.saidaId !== action.payload.saidaId,
+        ),
+      };
+    case 'RESET_STATE':
+      return initialState;
     default:
       return state;
   }

--- a/src/types/designacao.ts
+++ b/src/types/designacao.ts
@@ -4,4 +4,5 @@ export interface Designacao {
   saidaId: string;
   dataInicial: string;
   dataFinal: string;
+  devolvido?: boolean;
 }

--- a/src/utils/assignments.ts
+++ b/src/utils/assignments.ts
@@ -1,11 +1,11 @@
-import type { Assignment } from '../types/assignment';
+import type { Designacao } from '../types/designacao';
 
 export const getLastAssignmentDate = (
   territoryId: string,
-  assignments: Assignment[],
+  designacoes: Designacao[],
 ): Date | undefined => {
-  return assignments
-    .filter((assignment) => assignment.territoryId === territoryId)
-    .map((assignment) => new Date(`${assignment.startDate}T00:00:00`))
+  return designacoes
+    .filter((designacao) => designacao.territorioId === territoryId)
+    .map((designacao) => new Date(`${designacao.dataInicial}T00:00:00`))
     .sort((a, b) => b.getTime() - a.getTime())[0];
 };

--- a/src/utils/lookups.ts
+++ b/src/utils/lookups.ts
@@ -1,3 +1,11 @@
-export const findName = <T extends { id: string; name: string }>(id: string, list: T[]): string => {
-  return list.find((item) => item.id === id)?.name ?? '—';
+export const findName = <T extends { id: string }>(id: string, list: T[]): string => {
+  const item = list.find((entry) => entry.id === id);
+  if (!item) return '—';
+  if ('name' in item && typeof (item as { name?: string }).name === 'string') {
+    return (item as { name: string }).name;
+  }
+  if ('nome' in item && typeof (item as { nome?: string }).nome === 'string') {
+    return (item as { nome: string }).nome;
+  }
+  return '—';
 };


### PR DESCRIPTION
## Summary
- wrap the app with AppProvider and use repository-backed clear/reset handling
- implement Dexie-powered hooks for territórios, saídas, designações and sugestões with new reducer actions
- update feature pages to consume the new hooks and Portuguese models while persisting through repositories

## Testing
- npm test -- --run
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68c95c7e89d08325846ae4c048dd5bed