### PR TITLE
chore: remove placeholder pages

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,9 +3,9 @@ import { SchedulerControls } from './components/calendar/SchedulerControls';
 import { useConfirm } from './components/feedback/ConfirmDialog';
 import { Button } from './components/ui';
 import { Shell } from './components/layout/Shell';
-import PrediosVilasPage from './pages/PrediosVilas';
-import RuasNumeracoesPage from './pages/RuasNumeracoesPage';
 import TerritoriesPage from './pages/TerritoriesPage';
+import StreetsPage from './pages/RuasNumeracoesPage';
+import BuildingsVillagesPage from './pages/PrediosVilas';
 import ExitsPage from './pages/ExitsPage';
 import AssignmentsPage from './pages/AssignmentsPage';
 import CalendarPage from './pages/CalendarPage';
@@ -16,25 +16,19 @@ import { useToast } from './components/feedback/Toast';
 import { TerritorioRepository, SaidaRepository, DesignacaoRepository, SugestaoRepository } from './services/repositories';
 import type { TabKey } from './types/navigation';
 
+const pagesByTab: Record<TabKey, React.FC> = {
+  territories: TerritoriesPage,
+  streets: StreetsPage,
+  buildingsVillages: BuildingsVillagesPage,
+  exits: ExitsPage,
+  assignments: AssignmentsPage,
+  calendar: CalendarPage,
+  suggestions: SuggestionsPage,
+};
+
 const AppRoutes: React.FC<{ tab: TabKey }> = ({ tab }) => {
-  switch (tab) {
-    case 'territories':
-      return <TerritoriesPage />;
-    case 'streets':
-      return <RuasNumeracoesPage />;
-    case 'buildingsVillages':
-      return <PrediosVilasPage />;
-    case 'exits':
-      return <ExitsPage />;
-    case 'assignments':
-      return <AssignmentsPage />;
-    case 'calendar':
-      return <CalendarPage />;
-    case 'suggestions':
-      return <SuggestionsPage />;
-    default:
-      return null;
-  }
+  const PageComponent = pagesByTab[tab];
+  return <PageComponent />;
 };
 
 const ClearAllButton: React.FC = () => {

--- a/src/pages/Calendario.tsx
+++ b/src/pages/Calendario.tsx
@@ -1,3 +1,0 @@
-export default function Calendario(): JSX.Element {
-  return <div>Calendário</div>;
-}

--- a/src/pages/Config.tsx
+++ b/src/pages/Config.tsx
@@ -1,3 +1,0 @@
-export default function Config(): JSX.Element {
-  return <div>Configurações</div>;
-}

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -1,3 +1,0 @@
-export default function Dashboard(): JSX.Element {
-  return <div>Dashboard</div>;
-}

--- a/src/pages/Designacoes.tsx
+++ b/src/pages/Designacoes.tsx
@@ -1,3 +1,0 @@
-export default function Designacoes(): JSX.Element {
-  return <div>Designações</div>;
-}

--- a/src/pages/Saidas.tsx
+++ b/src/pages/Saidas.tsx
@@ -1,3 +1,0 @@
-export default function Saidas(): JSX.Element {
-  return <div>Saídas</div>;
-}

--- a/src/pages/Sugestoes.tsx
+++ b/src/pages/Sugestoes.tsx
@@ -1,3 +1,0 @@
-export default function Sugestoes(): JSX.Element {
-  return <div>Sugestões</div>;
-}

--- a/src/pages/Territorios.tsx
+++ b/src/pages/Territorios.tsx
@@ -1,3 +1,0 @@
-export default function Territorios(): JSX.Element {
-  return <div>Territórios</div>;
-}


### PR DESCRIPTION
## Summary
- remove the unused placeholder pages left in `src/pages`
- update the app routing to reference the implemented page components

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c96c6f7d3c8325a38ae3cc89816e42