### PR TITLE
Implement data export and import controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { SchedulerControls } from './components/calendar/SchedulerControls';
 import { useConfirm } from './components/feedback/ConfirmDialog';
 import { Button } from './components/ui';
@@ -13,7 +13,16 @@ import SuggestionsPage from './pages/SuggestionsPage';
 import { AppProvider } from './store/AppProvider';
 import { useApp } from './hooks/useApp';
 import { useToast } from './components/feedback/Toast';
-import { TerritorioRepository, SaidaRepository, DesignacaoRepository, SugestaoRepository } from './services/repositories';
+import { exportData } from './services/export';
+import { importData } from './services/import';
+import { db, SCHEMA_VERSION } from './services/db';
+import {
+  TerritorioRepository,
+  SaidaRepository,
+  DesignacaoRepository,
+  SugestaoRepository
+} from './services/repositories';
+import { BuildingVillageRepository } from './services/repositories/buildings_villages';
 import type { TabKey } from './types/navigation';
 
 const pagesByTab: Record<TabKey, React.FC> = {
@@ -31,10 +40,44 @@ const AppRoutes: React.FC<{ tab: TabKey }> = ({ tab }) => {
   return <PageComponent />;
 };
 
-const ClearAllButton: React.FC = () => {
+const DataManagementControls: React.FC = () => {
   const { dispatch } = useApp();
   const toast = useToast();
   const confirm = useConfirm();
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const handleExport = async () => {
+    try {
+      await exportData();
+      toast.success('Arquivo de exportação gerado');
+    } catch (error) {
+      console.error('Falha ao exportar dados', error);
+      toast.error('Não foi possível exportar os dados');
+    }
+  };
+
+  const handleImportClick = () => {
+    fileInputRef.current?.click();
+  };
+
+  const handleImportFile: React.ChangeEventHandler<HTMLInputElement> = async (event) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    try {
+      const data = await importData(file);
+      dispatch({ type: 'SET_TERRITORIOS', payload: data.territorios });
+      dispatch({ type: 'SET_SAIDAS', payload: data.saidas });
+      dispatch({ type: 'SET_DESIGNACOES', payload: data.designacoes });
+      dispatch({ type: 'SET_SUGESTOES', payload: data.sugestoes });
+      toast.success('Dados importados com sucesso');
+    } catch (error) {
+      console.error('Falha ao importar dados', error);
+      toast.error('Não foi possível importar os dados');
+    } finally {
+      event.target.value = '';
+    }
+  };
 
   const handleClick = async () => {
     if (!(await confirm('Limpar TODOS os dados?'))) {
@@ -47,7 +90,15 @@ const ClearAllButton: React.FC = () => {
         SaidaRepository.clear(),
         DesignacaoRepository.clear(),
         SugestaoRepository.clear(),
+        BuildingVillageRepository.clear(),
+        db.streets.clear(),
+        db.propertyTypes.clear(),
+        db.addresses.clear(),
+        db.derivedTerritories.clear(),
+        db.derivedTerritoryAddresses.clear(),
+        db.metadata.clear()
       ]);
+      await db.metadata.put({ key: 'schemaVersion', value: SCHEMA_VERSION });
       dispatch({ type: 'RESET_STATE' });
       toast.success('Dados limpos');
     } catch (error) {
@@ -57,10 +108,25 @@ const ClearAllButton: React.FC = () => {
   };
 
   return (
-    <div className="flex justify-end">
-      <Button onClick={handleClick} className="mt-4 bg-red-600 text-white">
-        Limpar TODOS os dados
-      </Button>
+    <div className="flex flex-col items-end gap-2">
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="application/json,application/*+json"
+        onChange={handleImportFile}
+        className="hidden"
+      />
+      <div className="flex flex-wrap justify-end gap-2">
+        <Button onClick={handleExport} className="mt-4 bg-neutral-100">
+          Exportar
+        </Button>
+        <Button onClick={handleImportClick} className="mt-4 bg-neutral-100">
+          Importar
+        </Button>
+        <Button onClick={handleClick} className="mt-4 bg-red-600 text-white">
+          Limpar TODOS os dados
+        </Button>
+      </div>
     </div>
   );
 };
@@ -73,7 +139,7 @@ export default function App() {
       <Shell currentTab={tab} onTabChange={setTab}>
         <AppRoutes tab={tab} />
         <SchedulerControls />
-        <ClearAllButton />
+        <DataManagementControls />
       </Shell>
     </AppProvider>
   );

--- a/src/services/data-transfer.ts
+++ b/src/services/data-transfer.ts
@@ -1,0 +1,142 @@
+import { z } from 'zod';
+import type { Territorio } from '../types/territorio';
+import type { Saida } from '../types/saida';
+import type { Designacao } from '../types/designacao';
+import type { Sugestao } from '../types/sugestao';
+import type { BuildingVillage } from '../types/building_village';
+import type { Street } from '../types/street';
+import type { PropertyType } from '../types/property-type';
+import type { Address } from '../types/address';
+import type { DerivedTerritory } from '../types/derived-territory';
+import type { Metadata } from './db';
+
+const territorioSchema = z.object({
+  id: z.string(),
+  nome: z.string(),
+  imagem: z.string().optional(),
+  imageUrl: z.string().optional()
+});
+
+const saidaSchema = z.object({
+  id: z.string(),
+  nome: z.string(),
+  diaDaSemana: z.number(),
+  hora: z.string()
+});
+
+const designacaoSchema = z.object({
+  id: z.string(),
+  territorioId: z.string(),
+  saidaId: z.string(),
+  dataInicial: z.string(),
+  dataFinal: z.string(),
+  devolvido: z.boolean().optional()
+});
+
+const sugestaoSchema = z.object({
+  territorioId: z.string(),
+  saidaId: z.string(),
+  dataInicial: z.string(),
+  dataFinal: z.string()
+});
+
+const buildingVillageSchema = z.object({
+  id: z.string(),
+  territory_id: z.string(),
+  name: z.string().nullable(),
+  address_line: z.string().nullable(),
+  type: z.string().nullable(),
+  number: z.string().nullable(),
+  residences_count: z.number().nullable(),
+  modality: z.string().nullable(),
+  reception_type: z.string().nullable(),
+  responsible: z.string().nullable(),
+  assigned_at: z.string().nullable(),
+  returned_at: z.string().nullable(),
+  block: z.string().nullable(),
+  notes: z.string().nullable(),
+  created_at: z.string().nullable()
+});
+
+const streetSchema = z.object({
+  id: z.number(),
+  territoryId: z.string(),
+  name: z.string()
+});
+
+const propertyTypeSchema = z.object({
+  id: z.number(),
+  name: z.string()
+});
+
+const addressSchema = z.object({
+  id: z.number(),
+  streetId: z.number(),
+  numberStart: z.number(),
+  numberEnd: z.number(),
+  propertyTypeId: z.number()
+});
+
+const derivedTerritorySchema = z.object({
+  id: z.number(),
+  baseTerritoryId: z.string(),
+  name: z.string()
+});
+
+const derivedTerritoryAddressSchema = z.object({
+  derivedTerritoryId: z.number(),
+  addressId: z.number()
+});
+
+const metadataSchema = z.object({
+  key: z.string(),
+  value: z.number()
+});
+
+export const exportedDataSchema = z
+  .object({
+    version: z.number().optional(),
+    exportedAt: z.string().optional(),
+    territorios: z.array(territorioSchema).optional().default([]),
+    saidas: z.array(saidaSchema).optional().default([]),
+    designacoes: z.array(designacaoSchema).optional().default([]),
+    sugestoes: z.array(sugestaoSchema).optional().default([]),
+    buildingsVillages: z.array(buildingVillageSchema).optional().default([]),
+    streets: z.array(streetSchema).optional().default([]),
+    propertyTypes: z.array(propertyTypeSchema).optional().default([]),
+    addresses: z.array(addressSchema).optional().default([]),
+    derivedTerritories: z.array(derivedTerritorySchema).optional().default([]),
+    derivedTerritoryAddresses: z.array(derivedTerritoryAddressSchema).optional().default([]),
+    metadata: z.array(metadataSchema).optional().default([])
+  })
+  .transform((data) => ({
+    ...data,
+    // Ensure arrays are always present even when defaults are used
+    territorios: data.territorios ?? [],
+    saidas: data.saidas ?? [],
+    designacoes: data.designacoes ?? [],
+    sugestoes: data.sugestoes ?? [],
+    buildingsVillages: data.buildingsVillages ?? [],
+    streets: data.streets ?? [],
+    propertyTypes: data.propertyTypes ?? [],
+    addresses: data.addresses ?? [],
+    derivedTerritories: data.derivedTerritories ?? [],
+    derivedTerritoryAddresses: data.derivedTerritoryAddresses ?? [],
+    metadata: data.metadata ?? []
+  }));
+
+export type ExportedData = {
+  version?: number;
+  exportedAt?: string;
+  territorios: Territorio[];
+  saidas: Saida[];
+  designacoes: Designacao[];
+  sugestoes: Sugestao[];
+  buildingsVillages: BuildingVillage[];
+  streets: Street[];
+  propertyTypes: PropertyType[];
+  addresses: Address[];
+  derivedTerritories: DerivedTerritory[];
+  derivedTerritoryAddresses: Array<{ derivedTerritoryId: number; addressId: number }>;
+  metadata: Metadata[];
+};

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -1,7 +1,80 @@
+import {
+  DesignacaoRepository,
+  SaidaRepository,
+  SugestaoRepository,
+  TerritorioRepository
+} from '../repositories';
+import { BuildingVillageRepository } from '../repositories/buildings_villages';
+import { db, SCHEMA_VERSION } from '../db';
+import type { ExportedData } from '../data-transfer';
+
+const formatTimestamp = (date: Date): string => {
+  const pad = (value: number) => value.toString().padStart(2, '0');
+  return [
+    date.getFullYear(),
+    pad(date.getMonth() + 1),
+    pad(date.getDate()),
+    pad(date.getHours()),
+    pad(date.getMinutes()),
+    pad(date.getSeconds())
+  ].join('');
+};
+
+const buildExportPayload = async (): Promise<ExportedData> => {
+  const [territorios, saidas, designacoes, sugestoes, buildingsVillages] = await Promise.all([
+    TerritorioRepository.all(),
+    SaidaRepository.all(),
+    DesignacaoRepository.all(),
+    SugestaoRepository.all(),
+    BuildingVillageRepository.all()
+  ]);
+
+  const [streets, propertyTypes, addresses, derivedTerritories, derivedTerritoryAddresses, metadata] =
+    await Promise.all([
+      db.streets.toArray(),
+      db.propertyTypes.toArray(),
+      db.addresses.toArray(),
+      db.derivedTerritories.toArray(),
+      db.derivedTerritoryAddresses.toArray(),
+      db.metadata.toArray()
+    ]);
+
+  return {
+    version: SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    territorios,
+    saidas,
+    designacoes,
+    sugestoes,
+    buildingsVillages,
+    streets,
+    propertyTypes,
+    addresses,
+    derivedTerritories,
+    derivedTerritoryAddresses,
+    metadata
+  };
+};
+
+const triggerDownload = (content: string): void => {
+  const blob = new Blob([content], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement('a');
+  const timestamp = formatTimestamp(new Date());
+
+  anchor.href = url;
+  anchor.download = `assigna-export-${timestamp}.json`;
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+  URL.revokeObjectURL(url);
+};
+
 /**
- * Exports all application data to a file.
- * This function is a placeholder and needs to be implemented.
+ * Exports all application data to a JSON file that the user can download.
  */
-export const exportData = () => {
-  // TODO: implement export logic
+export const exportData = async (): Promise<void> => {
+  const payload = await buildExportPayload();
+  const content = JSON.stringify(payload, null, 2);
+  triggerDownload(content);
 };

--- a/src/services/import/index.ts
+++ b/src/services/import/index.ts
@@ -1,7 +1,119 @@
+import { ZodError } from 'zod';
+import { exportedDataSchema, type ExportedData } from '../data-transfer';
+import {
+  DesignacaoRepository,
+  SaidaRepository,
+  SugestaoRepository,
+  TerritorioRepository
+} from '../repositories';
+import { BuildingVillageRepository } from '../repositories/buildings_villages';
+import { db, SCHEMA_VERSION } from '../db';
+
+type ImportSource = File | Blob | string;
+
+const readSource = async (source: ImportSource): Promise<string> => {
+  if (typeof source === 'string') {
+    return source;
+  }
+
+  return source.text();
+};
+
+const prepareMetadata = (data: ExportedData) => {
+  const entries = data.metadata.filter((item) => item.key !== 'schemaVersion');
+  entries.push({ key: 'schemaVersion', value: SCHEMA_VERSION });
+  return entries;
+};
+
 /**
- * Imports application data from a file.
- * This function is a placeholder and needs to be implemented.
+ * Imports application data from a JSON file and persists it in IndexedDB.
+ * @param source The file, blob or JSON string containing the exported data.
+ * @returns The data that was imported.
  */
-export const importData = () => {
-  // TODO: implement import logic
+export const importData = async (source: ImportSource): Promise<ExportedData> => {
+  const rawContent = await readSource(source);
+
+  let parsedContent: unknown;
+  try {
+    parsedContent = JSON.parse(rawContent);
+  } catch {
+    throw new Error('INVALID_JSON');
+  }
+
+  let data: ExportedData;
+  try {
+    data = exportedDataSchema.parse(parsedContent);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      throw new Error('INVALID_EXPORT_DATA');
+    }
+    throw error;
+  }
+
+  const metadataRecords = prepareMetadata(data);
+
+  await db.transaction(
+    'rw',
+    db.territorios,
+    db.saidas,
+    db.designacoes,
+    db.sugestoes,
+    db.buildingsVillages,
+    db.streets,
+    db.propertyTypes,
+    db.addresses,
+    db.derivedTerritories,
+    db.derivedTerritoryAddresses,
+    db.metadata,
+    async () => {
+      await Promise.all([
+        TerritorioRepository.clear(),
+        SaidaRepository.clear(),
+        DesignacaoRepository.clear(),
+        SugestaoRepository.clear(),
+        BuildingVillageRepository.clear(),
+        db.streets.clear(),
+        db.propertyTypes.clear(),
+        db.addresses.clear(),
+        db.derivedTerritories.clear(),
+        db.derivedTerritoryAddresses.clear(),
+        db.metadata.clear()
+      ]);
+
+      if (data.territorios.length > 0) {
+        await TerritorioRepository.bulkAdd(data.territorios);
+      }
+      if (data.saidas.length > 0) {
+        await SaidaRepository.bulkAdd(data.saidas);
+      }
+      if (data.designacoes.length > 0) {
+        await DesignacaoRepository.bulkAdd(data.designacoes);
+      }
+      if (data.sugestoes.length > 0) {
+        await SugestaoRepository.bulkAdd(data.sugestoes);
+      }
+      if (data.buildingsVillages.length > 0) {
+        await BuildingVillageRepository.bulkAdd(data.buildingsVillages);
+      }
+      if (data.streets.length > 0) {
+        await db.streets.bulkPut(data.streets);
+      }
+      if (data.propertyTypes.length > 0) {
+        await db.propertyTypes.bulkPut(data.propertyTypes);
+      }
+      if (data.addresses.length > 0) {
+        await db.addresses.bulkPut(data.addresses);
+      }
+      if (data.derivedTerritories.length > 0) {
+        await db.derivedTerritories.bulkPut(data.derivedTerritories);
+      }
+      if (data.derivedTerritoryAddresses.length > 0) {
+        await db.derivedTerritoryAddresses.bulkPut(data.derivedTerritoryAddresses);
+      }
+
+      await db.metadata.bulkPut(metadataRecords);
+    }
+  );
+
+  return { ...data, metadata: metadataRecords, version: SCHEMA_VERSION };
 };

--- a/src/services/repositories/buildings_villages.ts
+++ b/src/services/repositories/buildings_villages.ts
@@ -32,6 +32,14 @@ export const BuildingVillageRepository = {
   },
 
   /**
+   * Removes all building/village entries from the database.
+   * @returns A promise that resolves when the operation is complete.
+   */
+  async clear(): Promise<void> {
+    await db.buildingsVillages.clear();
+  },
+
+  /**
    * Removes a building/village entry from the database.
    * @param id The ID of the building/village to remove.
    * @returns A promise that resolves when the operation is complete.


### PR DESCRIPTION
## Summary
- add data management controls in the app shell to export, import and clear stored data
- implement JSON export and import services with schema validation and metadata handling
- extend the building/village repository and share data schemas for bulk operations

## Testing
- npm run lint
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68c96f78074083258cf19278029d644a