### PR TITLE
Implement HTTP notification service

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,14 @@ Atualmente não há variáveis de ambiente obrigatórias. Caso precise, crie um 
 EXAMPLE_API_KEY="sua_chave_aqui"
 ```
 
+Para habilitar a comunicação com um backend de notificações, configure também:
+
+```bash
+VITE_NOTIFICATIONS_API_URL="https://sua-api.com"
+```
+
+Quando essa variável não estiver definida, as notificações de devolução permanecerão apenas no modo offline.
+
 ## Screenshots
 
 Adicione imagens em `docs/screenshots/` com os nomes abaixo (ou ajuste os caminhos conforme preferir):

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -1,8 +1,0 @@
-/**
- * Fetches an example string from the API.
- * This is a placeholder and should be replaced with actual API calls.
- * @returns A promise that resolves to the string 'ok'.
- */
-export const fetchExample = async (): Promise<string> => {
-  return Promise.resolve('ok');
-};

--- a/src/services/notifications.ts
+++ b/src/services/notifications.ts
@@ -1,0 +1,46 @@
+const NOTIFICATION_ENDPOINT = '/notify';
+
+const normalizeBaseUrl = (baseUrl: string): string => {
+  return baseUrl.replace(/\/+$/, '');
+};
+
+const getNotificationsApiUrl = (): string | null => {
+  const configured = import.meta.env.VITE_NOTIFICATIONS_API_URL;
+  const trimmed = configured?.trim();
+  if (!trimmed) {
+    return null;
+  }
+  return `${normalizeBaseUrl(trimmed)}${NOTIFICATION_ENDPOINT}`;
+};
+
+export interface NotifyTerritoryReturnPayload {
+  endpoint: string;
+  territoryName: string;
+}
+
+const buildNotificationBody = (payload: NotifyTerritoryReturnPayload): Record<string, string> => ({
+  endpoint: payload.endpoint,
+  title: 'Território devolvido',
+  body: `${payload.territoryName} foi devolvido`,
+});
+
+export const notifyTerritoryReturn = async (
+  payload: NotifyTerritoryReturnPayload,
+): Promise<boolean> => {
+  const url = getNotificationsApiUrl();
+  if (!url) {
+    return false;
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(buildNotificationBody(payload)),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to notify territory return: ${response.status} ${response.statusText}`);
+  }
+
+  return true;
+};

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+declare global {
+  interface ImportMetaEnv {
+    readonly VITE_NOTIFICATIONS_API_URL?: string;
+  }
+}
+
+export {};


### PR DESCRIPTION
## Summary
- add a notifications service that performs HTTP calls when a backend is configured
- update the local store to use the new service for territory return notifications and log failures
- document the optional VITE_NOTIFICATIONS_API_URL environment variable and remove the unused API placeholder

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c9760fb98c83258f5a0e4ec8d49996