### PR TITLE
Add router navigation with sidebar links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^18.3.1",
         "react-hook-form": "^7.49.3",
         "react-i18next": "^15.5.1",
+        "react-router-dom": "file:vendor/react-router-dom",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -5945,6 +5946,10 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router-dom": {
+      "resolved": "vendor/react-router-dom",
+      "link": true
+    },
     "node_modules/read-cache": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/read-cache/-/read-cache-1.0.0.tgz",
@@ -7724,6 +7729,13 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "vendor/react-router-dom": {
+      "version": "0.0.0-local",
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-router-dom": "file:vendor/react-router-dom",
     "react-hook-form": "^7.49.3",
     "@hookform/resolvers": "^3.3.2",
     "zod": "^3.23.8",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,6 @@
-import React, { useRef, useState } from 'react';
+import { useRef } from 'react';
+import type { ComponentType } from 'react';
+import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
 import { SchedulerControls } from './components/calendar/SchedulerControls';
 import { useConfirm } from './components/feedback/ConfirmDialog';
 import { Button } from './components/ui';
@@ -24,8 +26,9 @@ import {
 } from './services/repositories';
 import { BuildingVillageRepository } from './services/repositories/buildings_villages';
 import type { TabKey } from './types/navigation';
+import { routeEntries } from './routes';
 
-const pagesByTab: Record<TabKey, React.FC> = {
+const pagesByTab: Record<TabKey, ComponentType> = {
   territories: TerritoriesPage,
   streets: StreetsPage,
   buildingsVillages: BuildingsVillagesPage,
@@ -33,11 +36,6 @@ const pagesByTab: Record<TabKey, React.FC> = {
   assignments: AssignmentsPage,
   calendar: CalendarPage,
   suggestions: SuggestionsPage,
-};
-
-const AppRoutes: React.FC<{ tab: TabKey }> = ({ tab }) => {
-  const PageComponent = pagesByTab[tab];
-  return <PageComponent />;
 };
 
 const DataManagementControls: React.FC = () => {
@@ -132,15 +130,21 @@ const DataManagementControls: React.FC = () => {
 };
 
 export default function App() {
-  const [tab, setTab] = useState<TabKey>('territories');
-
   return (
     <AppProvider>
-      <Shell currentTab={tab} onTabChange={setTab}>
-        <AppRoutes tab={tab} />
-        <SchedulerControls />
-        <DataManagementControls />
-      </Shell>
+      <BrowserRouter>
+        <Shell>
+          <Routes>
+            {routeEntries.map(([key, path]) => {
+              const PageComponent = pagesByTab[key];
+              return <Route key={key} path={path} element={<PageComponent />} />;
+            })}
+            <Route path="*" element={<Navigate to="/" replace />} />
+          </Routes>
+          <SchedulerControls />
+          <DataManagementControls />
+        </Shell>
+      </BrowserRouter>
     </AppProvider>
   );
 }

--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -1,14 +1,11 @@
 import React, { useLayoutEffect, useState } from 'react';
-import type { TabKey } from '../../types/navigation';
 import { Sidebar } from './Sidebar';
 
 interface ShellProps {
-  currentTab: TabKey;
-  onTabChange: (tab: TabKey) => void;
   children: React.ReactNode;
 }
 
-export const Shell: React.FC<ShellProps> = ({ currentTab, onTabChange, children }) => {
+export const Shell: React.FC<ShellProps> = ({ children }) => {
   const [dark, setDark] = useState<boolean>(() => {
     const stored = localStorage.getItem('dark');
     if (stored !== null) return JSON.parse(stored) as boolean;
@@ -24,7 +21,7 @@ export const Shell: React.FC<ShellProps> = ({ currentTab, onTabChange, children 
 
   return (
     <div className="min-h-screen text-neutral-900 dark:text-neutral-100 flex">
-      <Sidebar current={currentTab} onSelect={(value) => onTabChange(value as TabKey)} />
+      <Sidebar />
       <div className="flex-1">
         <header className="sticky top-0 z-10 backdrop-blur bg-white/60 dark:bg-neutral-950/50 border-b">
           <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -1,22 +1,11 @@
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-
-/**
- * Props for the Sidebar component.
- */
-interface Props {
-  /** The ID of the currently selected item. */
-  current: string;
-  /** Callback function for when an item is selected. */
-  onSelect: (id: string) => void;
-}
+import { NavLink } from 'react-router-dom';
+import type { TabKey } from '../../types/navigation';
+import { routePaths } from '../../routes';
 
 const iconCls = 'w-5 h-5';
 
-/**
- * An icon representing a map.
- * @returns A JSX element representing the map icon.
- */
 const MapIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M9 3L3 5v16l6-2 6 2 6-2V3l-6 2-6-2z" />
@@ -25,10 +14,6 @@ const MapIcon = () => (
   </svg>
 );
 
-/**
- * An icon representing an exit.
- * @returns A JSX element representing the exit icon.
- */
 const ExitIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M3 12h13" />
@@ -36,10 +21,6 @@ const ExitIcon = () => (
   </svg>
 );
 
-/**
- * An icon representing an assignment.
- * @returns A JSX element representing the assignment icon.
- */
 const AssignIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <rect x="6" y="3" width="12" height="18" rx="2" />
@@ -47,10 +28,6 @@ const AssignIcon = () => (
   </svg>
 );
 
-/**
- * An icon representing a calendar.
- * @returns A JSX element representing the calendar icon.
- */
 const CalendarIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <rect x="3" y="4" width="18" height="18" rx="2" />
@@ -60,10 +37,6 @@ const CalendarIcon = () => (
   </svg>
 );
 
-/**
- * An icon representing a suggestion.
- * @returns A JSX element representing the suggestion icon.
- */
 const SuggestIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M9 18h6" />
@@ -72,10 +45,6 @@ const SuggestIcon = () => (
   </svg>
 );
 
-/**
- * An icon representing a building.
- * @returns A JSX element representing the building icon.
- */
 const BuildingIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M3 21h18" />
@@ -87,7 +56,7 @@ const BuildingIcon = () => (
   </svg>
 );
 
-const items = [
+const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
   { id: 'territories', label: 'sidebar.territories', icon: <MapIcon /> },
   { id: 'streets', label: 'sidebar.streets', icon: <MapIcon /> },
   { id: 'buildingsVillages', label: 'sidebar.buildingsVillages', icon: <BuildingIcon /> },
@@ -97,26 +66,24 @@ const items = [
   { id: 'suggestions', label: 'sidebar.suggestions', icon: <SuggestIcon /> },
 ];
 
-/**
- * A component for the main sidebar navigation.
- * @param props The props for the component.
- * @returns A JSX element representing the sidebar.
- */
-export const Sidebar: React.FC<Props> = ({ current, onSelect }) => {
+export const Sidebar: React.FC = () => {
   const { t } = useTranslation();
+
   return (
     <nav className="bg-white dark:bg-neutral-900 border-r p-2 flex md:flex-col gap-2 md:w-48">
       {items.map((it) => (
-        <button
+        <NavLink
           key={it.id}
-          onClick={() => onSelect(it.id)}
-          className={`flex items-center gap-2 px-3 py-2 rounded transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800 ${
-            current === it.id ? 'bg-neutral-200 dark:bg-neutral-800' : ''
+          to={routePaths[it.id]}
+          end={routePaths[it.id] === '/'}
+          className={({ isActive }) => `flex items-center gap-2 px-3 py-2 rounded transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800
+${
+            isActive ? 'bg-neutral-200 dark:bg-neutral-800' : ''
           }`}
         >
           {it.icon}
           <span className="hidden md:inline">{t(it.label)}</span>
-        </button>
+        </NavLink>
       ))}
     </nav>
   );

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,0 +1,16 @@
+import type { TabKey } from './types/navigation';
+
+export const routePaths: Record<TabKey, string> = {
+  territories: '/',
+  streets: '/streets',
+  buildingsVillages: '/buildings-villages',
+  exits: '/exits',
+  assignments: '/assignments',
+  calendar: '/calendar',
+  suggestions: '/suggestions'
+};
+
+export const routeEntries = Object.entries(routePaths) as Array<[
+  TabKey,
+  string
+]>;

--- a/vendor/react-router-dom/index.d.ts
+++ b/vendor/react-router-dom/index.d.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+export interface BrowserRouterProps {
+  children?: React.ReactNode;
+}
+export declare function BrowserRouter(props: BrowserRouterProps): React.ReactElement;
+
+export interface RouteProps {
+  path?: string;
+  element?: React.ReactNode;
+}
+export declare function Route(props: RouteProps): null;
+
+export interface RoutesProps {
+  children?: React.ReactNode;
+}
+export declare function Routes(props: RoutesProps): React.ReactElement | null;
+
+export interface NavLinkRenderProps {
+  isActive: boolean;
+  isPending: boolean;
+}
+
+export interface NavLinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string | { pathname?: string };
+  end?: boolean;
+  className?: string | ((props: NavLinkRenderProps) => string | undefined);
+  children?: React.ReactNode | ((props: NavLinkRenderProps) => React.ReactNode);
+}
+export declare function NavLink(props: NavLinkProps): React.ReactElement;
+
+export interface NavigateOptions {
+  replace?: boolean;
+}
+export declare function useNavigate(): (to: string | { pathname?: string }, options?: NavigateOptions) => void;
+
+export interface Location {
+  pathname: string;
+}
+export declare function useLocation(): Location;
+
+export interface NavigateProps {
+  to: string | { pathname?: string };
+  replace?: boolean;
+}
+export declare function Navigate(props: NavigateProps): null;

--- a/vendor/react-router-dom/index.js
+++ b/vendor/react-router-dom/index.js
@@ -1,0 +1,173 @@
+import * as React from 'react';
+
+const RouterContext = React.createContext({
+  location: { pathname: '/' },
+  navigate: () => {
+    throw new Error('navigate called outside of a router context');
+  }
+});
+
+const isBrowser = typeof window !== 'undefined';
+
+const readPathname = () => {
+  if (!isBrowser) return '/';
+  const { pathname } = window.location;
+  return pathname || '/';
+};
+
+function normalizePath(path) {
+  if (!path) return '/';
+  if (path.length > 1 && path.endsWith('/')) {
+    return path.slice(0, -1);
+  }
+  return path;
+}
+
+function matchExact(path, pathname) {
+  return normalizePath(path) === normalizePath(pathname);
+}
+
+function matchLoose(path, pathname) {
+  const base = normalizePath(path);
+  const target = normalizePath(pathname);
+  if (base === '/') return target === '/';
+  return target === base || target.startsWith(base + '/');
+}
+
+export function BrowserRouter({ children }) {
+  const [pathname, setPathname] = React.useState(() => readPathname());
+
+  React.useEffect(() => {
+    if (!isBrowser) return undefined;
+    const handler = () => {
+      setPathname(readPathname());
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, []);
+
+  const navigate = React.useCallback((to, options = {}) => {
+    const target = typeof to === 'string' ? to : to?.pathname ?? '/';
+    if (isBrowser) {
+      if (options.replace) {
+        window.history.replaceState({}, '', target);
+      } else {
+        window.history.pushState({}, '', target);
+      }
+      setPathname(readPathname());
+    } else {
+      setPathname(target);
+    }
+  }, []);
+
+  const location = React.useMemo(() => ({ pathname }), [pathname]);
+
+  const value = React.useMemo(
+    () => ({
+      location,
+      navigate
+    }),
+    [location, navigate]
+  );
+
+  return React.createElement(RouterContext.Provider, { value }, children);
+}
+
+export function useNavigate() {
+  const context = React.useContext(RouterContext);
+  if (!context) {
+    throw new Error('useNavigate must be used within a BrowserRouter');
+  }
+  return context.navigate;
+}
+
+export function useLocation() {
+  const context = React.useContext(RouterContext);
+  if (!context) {
+    throw new Error('useLocation must be used within a BrowserRouter');
+  }
+  return context.location;
+}
+
+export function Navigate({ to, replace = false }) {
+  const navigate = useNavigate();
+  React.useEffect(() => {
+    const target = typeof to === 'string' ? to : to?.pathname ?? '/';
+    navigate(target, { replace });
+  }, [navigate, replace, to]);
+  return null;
+}
+
+export function Routes({ children }) {
+  const { location } = React.useContext(RouterContext);
+  const pathname = location.pathname;
+  const childArray = React.Children.toArray(children);
+
+  for (const child of childArray) {
+    if (!React.isValidElement(child)) continue;
+    const { path = '*', element } = child.props || {};
+    if (path === '*' || matchExact(path, pathname)) {
+      return React.createElement(React.Fragment, null, element ?? null);
+    }
+  }
+
+  return null;
+}
+
+export function Route() {
+  return null;
+}
+
+export function NavLink({
+  to,
+  className,
+  children,
+  end = false,
+  onClick,
+  ...rest
+}) {
+  const { location, navigate } = React.useContext(RouterContext);
+  const href = typeof to === 'string' ? to : to?.pathname ?? '/';
+  const isActive = end ? matchExact(href, location.pathname) : matchLoose(href, location.pathname);
+
+  const classValue =
+    typeof className === 'function'
+      ? className({ isActive, isPending: false }) ?? undefined
+      : className;
+
+  const childValue =
+    typeof children === 'function'
+      ? children({ isActive, isPending: false })
+      : children;
+
+  const handleClick = event => {
+    if (onClick) {
+      onClick(event);
+    }
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      (rest.target && rest.target !== '_self') ||
+      event.metaKey ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.shiftKey
+    ) {
+      return;
+    }
+    event.preventDefault();
+    navigate(href);
+  };
+
+  return React.createElement(
+    'a',
+    {
+      ...rest,
+      href,
+      className: classValue,
+      'aria-current': isActive ? 'page' : undefined,
+      onClick: handleClick
+    },
+    childValue
+  );
+}

--- a/vendor/react-router-dom/package.json
+++ b/vendor/react-router-dom/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "react-router-dom",
+  "version": "0.0.0-local",
+  "type": "module",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js"
+  },
+  "types": "./index.d.ts",
+  "peerDependencies": {
+    "react": ">=18",
+    "react-dom": ">=18"
+  }
+}


### PR DESCRIPTION
## Summary
- add a local react-router-dom package stub and wire it into dependencies
- configure top-level routes with BrowserRouter/Routes and share path constants
- update shell/sidebar to consume NavLink navigation instead of manual tab state

## Testing
- npm run lint
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c97bf3403c8325a65376eb73df9506