### PR TITLE
Ajusta acessibilidade da barra lateral

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -76,13 +76,14 @@ export const Sidebar: React.FC = () => {
           key={it.id}
           to={routePaths[it.id]}
           end={routePaths[it.id] === '/'}
+          aria-label={t(it.label)}
           className={({ isActive }) => `flex items-center gap-2 px-3 py-2 rounded transition-colors hover:bg-neutral-100 dark:hover:bg-neutral-800
 ${
             isActive ? 'bg-neutral-200 dark:bg-neutral-800' : ''
           }`}
         >
           {it.icon}
-          <span className="hidden md:inline">{t(it.label)}</span>
+          <span className="sr-only md:not-sr-only md:inline">{t(it.label)}</span>
         </NavLink>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- adiciona `aria-label` aos itens da barra lateral para expor o texto traduzido a leitores de tela
- troca a classe `hidden` por `sr-only` nos rótulos dos itens da barra lateral para manter o conteúdo acessível em telas pequenas

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68c994ac267c83258fbbde66ec972c58