### PR TITLE
Localize calendar page labels

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -83,6 +83,12 @@
     "confirmDelete": "Delete assignment?",
     "delete": "Delete"
   },
+  "calendar": {
+    "warningDays": "Alert (days)",
+    "overdue": "Overdue",
+    "dueIn": "D-{{diff}}",
+    "noAssignments": "No assignments."
+  },
   "app": {
     "updateAvailable": "New version available. Update?",
     "loading": "Loading...",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -83,6 +83,12 @@
     "confirmDelete": "¿Eliminar asignación?",
     "delete": "Eliminar"
   },
+  "calendar": {
+    "warningDays": "Alerta (días)",
+    "overdue": "Atrasado",
+    "dueIn": "D-{{diff}}",
+    "noAssignments": "Sin asignaciones."
+  },
   "app": {
     "updateAvailable": "Nova versão disponível. Atualizar?",
     "loading": "Carregando...",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -83,6 +83,12 @@
     "confirmDelete": "Excluir designação?",
     "delete": "Excluir"
   },
+  "calendar": {
+    "warningDays": "Alerta (dias)",
+    "overdue": "Atrasado",
+    "dueIn": "D-{{diff}}",
+    "noAssignments": "Sem designações."
+  },
   "app": {
     "updateAvailable": "Nova versão disponível. Atualizar?",
     "loading": "Carregando...",

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Modal } from '../components/layout/Modal';
 import { Card, Button, Input, Label } from '../components/ui';
 import { useDesignacoes } from '../hooks/useDesignacoes';
@@ -13,6 +14,7 @@ const CalendarPage: React.FC = () => {
   const [warningDays, setWarningDays] = useWarningDays();
   const [month, setMonth] = useState(() => new Date());
   const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  const { t } = useTranslation();
   const today = new Date();
   const toIso = (date: Date) => date.toISOString().slice(0, 10);
 
@@ -43,7 +45,7 @@ const CalendarPage: React.FC = () => {
             </Button>
           </div>
           <div className="flex items-center gap-2">
-            <Label>Alerta (dias)</Label>
+            <Label>{t('calendar.warningDays')}</Label>
             <Input
               type="number"
               min={0}
@@ -84,9 +86,18 @@ const CalendarPage: React.FC = () => {
                   const diff = Math.ceil((new Date(designacao.dataFinal).getTime() - today.getTime()) / 86400000);
                   let badge: React.ReactNode = null;
                   if (!designacao.devolvido) {
-                    if (diff < 0) badge = <span className="ml-1 text-[10px] px-1 rounded bg-red-600 text-white">Atrasado</span>;
+                    if (diff < 0)
+                      badge = (
+                        <span className="ml-1 text-[10px] px-1 rounded bg-red-600 text-white">
+                          {t('calendar.overdue')}
+                        </span>
+                      );
                     else if (diff <= warningDays)
-                      badge = <span className="ml-1 text-[10px] px-1 rounded bg-orange-500 text-white">D-{diff}</span>;
+                      badge = (
+                        <span className="ml-1 text-[10px] px-1 rounded bg-orange-500 text-white">
+                          {t('calendar.dueIn', { diff })}
+                        </span>
+                      );
                   }
                   return (
                     <div key={designacao.id} className="text-[10px] truncate">
@@ -110,7 +121,7 @@ const CalendarPage: React.FC = () => {
                 (designacao) => designacao.dataInicial === selectedDay || designacao.dataFinal === selectedDay,
               );
               return items.length === 0 ? (
-                <p className="text-sm text-neutral-500">Sem designações.</p>
+                <p className="text-sm text-neutral-500">{t('calendar.noAssignments')}</p>
               ) : (
                 <ul className="text-sm grid gap-1">
                   {items.map((assignment) => (
@@ -124,7 +135,7 @@ const CalendarPage: React.FC = () => {
             })()}
             <div className="text-right">
               <Button onClick={close} className="bg-neutral-100">
-                Fechar
+                {t('app.close')}
               </Button>
             </div>
           </div>


### PR DESCRIPTION
## Summary
- integrate the calendar page with the translation hook and replace hard-coded strings with locale keys
- add calendar-specific phrases to each locale file to support the new translations

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c99fe819b083258844545550302090