### PR TITLE
Localize exits page labels

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -63,6 +63,18 @@
     "inativo": "Inactive",
     "arquivado": "Archived"
   },
+  "exits": {
+    "newExit": "Create field exit",
+    "name": "Name",
+    "namePlaceholder": "E.g.: Saturday Morning Group",
+    "weekday": "Weekday",
+    "time": "Time",
+    "save": "Save exit",
+    "exitsWithCount": "Field exits ({{count}})",
+    "noExits": "No exits registered.",
+    "confirmDelete": "Delete exit?",
+    "delete": "Delete"
+  },
   "assignments": {
     "selectExit": "Select an exit",
     "noAvailableTerritories": "No territories available",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -63,6 +63,18 @@
     "inativo": "Inativo",
     "arquivado": "Arquivado"
   },
+  "exits": {
+    "newExit": "Registrar salida de campo",
+    "name": "Nombre",
+    "namePlaceholder": "Ej.: Grupo Sábado Mañana",
+    "weekday": "Día de la semana",
+    "time": "Horario",
+    "save": "Guardar salida",
+    "exitsWithCount": "Salidas ({{count}})",
+    "noExits": "Ninguna salida registrada.",
+    "confirmDelete": "¿Eliminar salida?",
+    "delete": "Eliminar"
+  },
   "assignments": {
     "selectExit": "Seleccione una salida",
     "noAvailableTerritories": "No hay territorios disponibles",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -63,6 +63,18 @@
     "inativo": "Inativo",
     "arquivado": "Arquivado"
   },
+  "exits": {
+    "newExit": "Cadastrar Saída de Campo",
+    "name": "Nome",
+    "namePlaceholder": "Ex.: Grupo Sábado Manhã",
+    "weekday": "Dia da Semana",
+    "time": "Horário",
+    "save": "Salvar Saída",
+    "exitsWithCount": "Saídas ({{count}})",
+    "noExits": "Nenhuma saída cadastrada.",
+    "confirmDelete": "Excluir saída?",
+    "delete": "Excluir"
+  },
   "assignments": {
     "selectExit": "Selecione uma saída",
     "noAvailableTerritories": "Sem territórios disponíveis",

--- a/src/pages/ExitsPage.tsx
+++ b/src/pages/ExitsPage.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useConfirm } from '../components/feedback/ConfirmDialog';
 import { Card, Button, Input, Label } from '../components/ui';
 import { useSaidas } from '../hooks/useSaidas';
@@ -7,6 +8,7 @@ import { weekdays } from '../utils/calendar';
 const ExitsPage: React.FC = () => {
   const { saidas, addSaida, removeSaida } = useSaidas();
   const confirm = useConfirm();
+  const { t } = useTranslation();
   const [nome, setNome] = useState('');
   const [diaDaSemana, setDiaDaSemana] = useState<number>(6);
   const [hora, setHora] = useState('09:00');
@@ -22,14 +24,18 @@ const ExitsPage: React.FC = () => {
 
   return (
     <div className="grid gap-4">
-      <Card title="Cadastrar Saída de Campo">
+      <Card title={t('exits.newExit')}>
         <form onSubmit={submit} className="grid md:grid-cols-4 gap-3">
           <div className="grid gap-1">
-            <Label>Nome</Label>
-            <Input value={nome} onChange={(event) => setNome(event.target.value)} placeholder="Ex.: Grupo Sábado Manhã" />
+            <Label>{t('exits.name')}</Label>
+            <Input
+              value={nome}
+              onChange={(event) => setNome(event.target.value)}
+              placeholder={t('exits.namePlaceholder')}
+            />
           </div>
           <div className="grid gap-1">
-            <Label>Dia da Semana</Label>
+            <Label>{t('exits.weekday')}</Label>
             <select
               value={diaDaSemana}
               onChange={(event) => setDiaDaSemana(Number(event.target.value))}
@@ -43,20 +49,20 @@ const ExitsPage: React.FC = () => {
             </select>
           </div>
           <div className="grid gap-1">
-            <Label>Horário</Label>
+            <Label>{t('exits.time')}</Label>
             <Input type="time" value={hora} onChange={(event) => setHora(event.target.value)} />
           </div>
           <div className="flex items-end justify-end">
             <Button type="submit" className="bg-black text-white">
-              Salvar Saída
+              {t('exits.save')}
             </Button>
           </div>
         </form>
       </Card>
 
-      <Card title={`Saídas (${saidas.length})`}>
+      <Card title={t('exits.exitsWithCount', { count: saidas.length })}>
         {saidas.length === 0 ? (
-          <p className="text-neutral-500">Nenhuma saída cadastrada.</p>
+          <p className="text-neutral-500">{t('exits.noExits')}</p>
         ) : (
           <div className="grid md:grid-cols-2 gap-3">
             {saidas.map((saida) => (
@@ -69,13 +75,13 @@ const ExitsPage: React.FC = () => {
                 </div>
                 <Button
                   onClick={async () => {
-                    if (await confirm('Excluir saída?')) {
+                    if (await confirm(t('exits.confirmDelete'))) {
                       await removeSaida(saida.id);
                     }
                   }}
                   className="bg-red-50 text-red-700"
                 >
-                  Excluir
+                  {t('exits.delete')}
                 </Button>
               </div>
             ))}


### PR DESCRIPTION
## Summary
- replace the Exits page strings with i18n lookups using useTranslation
- add the exits namespace with all required labels in en-US, pt-BR, and es-ES locales

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a16a5314832595f7535021fa6461