### PR TITLE
feat: add reports title translation

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -101,6 +101,9 @@
     "dueIn": "D-{{diff}}",
     "noAssignments": "No assignments."
   },
+  "reports": {
+    "title": "Reports"
+  },
   "app": {
     "updateAvailable": "New version available. Update?",
     "loading": "Loading...",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -101,6 +101,9 @@
     "dueIn": "D-{{diff}}",
     "noAssignments": "Sin asignaciones."
   },
+  "reports": {
+    "title": "Informes"
+  },
   "app": {
     "updateAvailable": "Nova versão disponível. Atualizar?",
     "loading": "Carregando...",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -101,6 +101,9 @@
     "dueIn": "D-{{diff}}",
     "noAssignments": "Sem designações."
   },
+  "reports": {
+    "title": "Relatórios"
+  },
   "app": {
     "updateAvailable": "Nova versão disponível. Atualizar?",
     "loading": "Carregando...",

--- a/src/pages/Relatorios.tsx
+++ b/src/pages/Relatorios.tsx
@@ -1,3 +1,7 @@
+import { useTranslation } from 'react-i18next';
+
 export default function Relatorios(): JSX.Element {
-  return <div>Relatórios</div>;
+  const { t } = useTranslation();
+
+  return <div>{t('reports.title')}</div>;
 }


### PR DESCRIPTION
## Summary
- render the reports page heading using the translation hook
- add the reports.title key to all locale files

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a4ee901c8325a70650a1c189e2eb