### PR TITLE
Add Spanish locale support

### DIFF
--- a/src/components/forms/LanguageSelector.test.tsx
+++ b/src/components/forms/LanguageSelector.test.tsx
@@ -79,4 +79,25 @@ describe('LanguageSelector', () => {
       cleanup();
     }
   });
+
+  it('renders the spanish locale when selected', () => {
+    mockI18n.language = 'es-ES';
+    localStorage.setItem('locale', 'es-ES');
+
+    const { container, cleanup } = renderSelector();
+
+    try {
+      const select = container.querySelector('select');
+      if (!select) throw new Error('Language selector not found');
+
+      const optionValues = Array.from(select.querySelectorAll('option')).map(
+        (option) => option.value
+      );
+
+      expect(optionValues).toContain('es-ES');
+      expect(select.value).toBe('es-ES');
+    } finally {
+      cleanup();
+    }
+  });
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,6 +1,7 @@
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import en from './locales/en-US/translation.json';
+import es from './locales/es-ES/translation.json';
 import pt from './locales/pt-BR/translation.json';
 
 const stored = typeof window !== 'undefined' ? localStorage.getItem('locale') : null;
@@ -10,6 +11,7 @@ i18n
   .init({
     resources: {
       'en-US': { translation: en },
+      'es-ES': { translation: es },
       'pt-BR': { translation: pt }
     },
     lng: stored || 'en-US',


### PR DESCRIPTION
## Summary
- register the es-ES translation bundle with the i18next resources
- extend the language selector tests to ensure the Spanish locale remains selectable

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9a99b06408325beb6700e5e43ec0a