### PR TITLE
Localize data management notifications

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useRef } from 'react';
 import type { ComponentType } from 'react';
 import { BrowserRouter, Navigate, Route, Routes } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
 import { SchedulerControls } from './components/calendar/SchedulerControls';
 import { useConfirm } from './components/feedback/ConfirmDialog';
 import { Button } from './components/ui';
@@ -42,15 +43,16 @@ const DataManagementControls: React.FC = () => {
   const { dispatch } = useApp();
   const toast = useToast();
   const confirm = useConfirm();
+  const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
 
   const handleExport = async () => {
     try {
       await exportData();
-      toast.success('Arquivo de exportação gerado');
+      toast.success(t('app.exportSuccess'));
     } catch (error) {
-      console.error('Falha ao exportar dados', error);
-      toast.error('Não foi possível exportar os dados');
+      console.error(t('app.exportError'), error);
+      toast.error(t('app.exportError'));
     }
   };
 
@@ -68,17 +70,17 @@ const DataManagementControls: React.FC = () => {
       dispatch({ type: 'SET_SAIDAS', payload: data.saidas });
       dispatch({ type: 'SET_DESIGNACOES', payload: data.designacoes });
       dispatch({ type: 'SET_SUGESTOES', payload: data.sugestoes });
-      toast.success('Dados importados com sucesso');
+      toast.success(t('app.importSuccess'));
     } catch (error) {
-      console.error('Falha ao importar dados', error);
-      toast.error('Não foi possível importar os dados');
+      console.error(t('app.importError'), error);
+      toast.error(t('app.importError'));
     } finally {
       event.target.value = '';
     }
   };
 
   const handleClick = async () => {
-    if (!(await confirm('Limpar TODOS os dados?'))) {
+    if (!(await confirm(t('app.clearConfirm')))) {
       return;
     }
 
@@ -98,10 +100,10 @@ const DataManagementControls: React.FC = () => {
       ]);
       await db.metadata.put({ key: 'schemaVersion', value: SCHEMA_VERSION });
       dispatch({ type: 'RESET_STATE' });
-      toast.success('Dados limpos');
+      toast.success(t('app.clearSuccess'));
     } catch (error) {
-      console.error('Falha ao limpar dados', error);
-      toast.error('Não foi possível limpar os dados');
+      console.error(t('app.clearError'), error);
+      toast.error(t('app.clearError'));
     }
   };
 

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -280,7 +280,14 @@
     "copy": "Copy",
     "copied": "Copied to clipboard",
     "noData": "No data available",
-    "search": "Search"
+    "search": "Search",
+    "exportSuccess": "Export file generated",
+    "exportError": "Unable to export data",
+    "importSuccess": "Data imported successfully",
+    "importError": "Unable to import data",
+    "clearConfirm": "Clear ALL data?",
+    "clearSuccess": "Data cleared",
+    "clearError": "Unable to clear data"
   },
   "language": {
     "english": "English",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -282,7 +282,14 @@
     "copy": "Copiar",
     "copied": "Copiado para a área de transferência",
     "noData": "Nenhum dado disponível",
-    "search": "Pesquisar"
+    "search": "Pesquisar",
+    "exportSuccess": "Archivo de exportación generado",
+    "exportError": "No se pudieron exportar los datos",
+    "importSuccess": "Datos importados con éxito",
+    "importError": "No se pudieron importar los datos",
+    "clearConfirm": "¿Borrar TODOS los datos?",
+    "clearSuccess": "Datos borrados",
+    "clearError": "No se pudieron borrar los datos"
   },
   "language": {
     "english": "Inglês",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -282,7 +282,14 @@
     "copy": "Copiar",
     "copied": "Copiado para a área de transferência",
     "noData": "Nenhum dado disponível",
-    "search": "Pesquisar"
+    "search": "Pesquisar",
+    "exportSuccess": "Arquivo de exportação gerado",
+    "exportError": "Não foi possível exportar os dados",
+    "importSuccess": "Dados importados com sucesso",
+    "importError": "Não foi possível importar os dados",
+    "clearConfirm": "Limpar TODOS os dados?",
+    "clearSuccess": "Dados limpos",
+    "clearError": "Não foi possível limpar os dados"
   },
   "language": {
     "english": "Inglês",


### PR DESCRIPTION
## Summary
- replace hardcoded data management feedback messages with i18n translations
- add export/import/clear status strings to the pt-BR, en-US, and es-ES locale files

## Testing
- npm run lint
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9aa8e7e408325882a442abada35b1