### PR TITLE
Add testing utilities and coverage for territories and streets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Run unit tests
+        run: npm run test -- --run

--- a/src/hooks/useTerritorios.test.ts
+++ b/src/hooks/useTerritorios.test.ts
@@ -1,0 +1,151 @@
+import type { AppState } from '../store/appReducer';
+import type { Territorio } from '../types/territorio';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+
+const {
+  repositoryAddMock,
+  repositoryRemoveMock,
+  useToastMock,
+  toastSuccessMock,
+  generateIdMock,
+} = vi.hoisted(() => ({
+  repositoryAddMock: vi.fn(async () => {}),
+  repositoryRemoveMock: vi.fn(async () => {}),
+  useToastMock: vi.fn(),
+  toastSuccessMock: vi.fn(),
+  generateIdMock: vi.fn(() => 'generated-id'),
+}));
+
+vi.mock('./useApp', () => ({
+  useApp: vi.fn(),
+}));
+
+vi.mock('../store/selectors', () => ({
+  selectTerritorios: vi.fn(),
+}));
+
+vi.mock('../services/repositories', () => ({
+  TerritorioRepository: {
+    add: repositoryAddMock,
+    remove: repositoryRemoveMock,
+  },
+}));
+
+vi.mock('../components/feedback/Toast', () => ({
+  useToast: useToastMock,
+}));
+
+vi.mock('../utils/id', () => ({
+  generateId: generateIdMock,
+}));
+
+import { useTerritorios } from './useTerritorios';
+import { useApp } from './useApp';
+import { selectTerritorios } from '../store/selectors';
+
+type Dispatch = ReturnType<typeof vi.fn>;
+
+const mockedUseApp = vi.mocked(useApp);
+const mockedSelectTerritorios = vi.mocked(selectTerritorios);
+
+let state: AppState;
+let dispatchSpy: Dispatch;
+
+beforeEach(() => {
+  state = {
+    territorios: [
+      {
+        id: 'territorio-inicial',
+        nome: 'Território Inicial',
+      },
+    ],
+    saidas: [],
+    designacoes: [],
+    sugestoes: [],
+  };
+  dispatchSpy = vi.fn();
+
+  repositoryAddMock.mockClear();
+  repositoryRemoveMock.mockClear();
+  useToastMock.mockClear();
+  toastSuccessMock.mockClear();
+  generateIdMock.mockClear();
+
+  useToastMock.mockReturnValue({ success: toastSuccessMock });
+  mockedUseApp.mockReturnValue({ state, dispatch: dispatchSpy });
+  mockedSelectTerritorios.mockReturnValue(state.territorios);
+  generateIdMock.mockReturnValue('generated-id');
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('useTerritorios', () => {
+  it('exposes the territorios selected from the state', () => {
+    const selected: Territorio[] = [
+      { id: 'territorio-2', nome: 'Outro Território' },
+    ];
+    mockedSelectTerritorios.mockReturnValueOnce(selected);
+
+    const { result } = renderHook(() => useTerritorios());
+
+    expect(mockedSelectTerritorios).toHaveBeenCalledWith(state);
+    expect(result.current.territorios).toBe(selected);
+  });
+
+  it('persists and dispatches a new território when addTerritorio is called', async () => {
+    const { result } = renderHook(() => useTerritorios());
+    const payload = { nome: 'Novo Território' };
+
+    let created: Territorio | undefined;
+    await act(async () => {
+      created = await result.current.addTerritorio(payload);
+    });
+
+    expect(generateIdMock).toHaveBeenCalled();
+    expect(repositoryAddMock).toHaveBeenCalledWith({ id: 'generated-id', ...payload });
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'ADD_TERRITORIO',
+      payload: { id: 'generated-id', ...payload },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('Território salvo');
+    expect(created).toEqual({ id: 'generated-id', ...payload });
+  });
+
+  it('updates an existing território using updateTerritorio', async () => {
+    const { result } = renderHook(() => useTerritorios());
+    const updatePayload: Omit<Territorio, 'id'> = {
+      nome: 'Território Atualizado',
+    };
+
+    let updated: Territorio | undefined;
+    await act(async () => {
+      updated = await result.current.updateTerritorio('territorio-1', updatePayload);
+    });
+
+    expect(repositoryAddMock).toHaveBeenCalledWith({ id: 'territorio-1', ...updatePayload });
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'UPDATE_TERRITORIO',
+      payload: { id: 'territorio-1', ...updatePayload },
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('Território atualizado');
+    expect(updated).toEqual({ id: 'territorio-1', ...updatePayload });
+  });
+
+  it('removes a território when removeTerritorio is invoked', async () => {
+    const { result } = renderHook(() => useTerritorios());
+
+    await act(async () => {
+      await result.current.removeTerritorio('territorio-3');
+    });
+
+    expect(repositoryRemoveMock).toHaveBeenCalledWith('territorio-3');
+    expect(dispatchSpy).toHaveBeenCalledWith({
+      type: 'REMOVE_TERRITORIO',
+      payload: 'territorio-3',
+    });
+    expect(toastSuccessMock).toHaveBeenCalledWith('Território removido');
+  });
+});

--- a/src/pages/RuasNumeracoesPage.test.tsx
+++ b/src/pages/RuasNumeracoesPage.test.tsx
@@ -1,0 +1,345 @@
+import type { Territorio } from '../types/territorio';
+import type { Street } from '../types/street';
+import type { PropertyType } from '../types/property-type';
+import type { Address } from '../types/address';
+import type { AddressForm } from './RuasNumeracoesPage';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
+
+const {
+  territoriesStore,
+  streetsStore,
+  propertyTypesStore,
+  addressesStore,
+  dbMock,
+} = vi.hoisted(() => {
+  const territoriesStore: Territorio[] = [];
+  const streetsStore: Street[] = [];
+  const propertyTypesStore: PropertyType[] = [];
+  const addressesStore: Address[] = [];
+
+  const nextNumericId = (collection: Array<{ id?: number }>): number => {
+    const maxId = collection.reduce((max, item) => {
+      if (typeof item.id === 'number') {
+        return Math.max(max, item.id);
+      }
+      return max;
+    }, 0);
+    return maxId + 1;
+  };
+
+  const dbMock = {
+    territorios: {
+      toArray: vi.fn(async () => territoriesStore.map((territory) => ({ ...territory }))),
+    },
+    streets: {
+      toArray: vi.fn(async () => streetsStore.map((street) => ({ ...street }))),
+      put: vi.fn(async (street: Street) => {
+        const id = typeof street.id === 'number' ? street.id : nextNumericId(streetsStore);
+        const record: Street = { id, ...street };
+        const index = streetsStore.findIndex((item) => item.id === id);
+        if (index >= 0) {
+          streetsStore[index] = record;
+        } else {
+          streetsStore.push(record);
+        }
+        return id;
+      }),
+    },
+    propertyTypes: {
+      toArray: vi.fn(async () => propertyTypesStore.map((type) => ({ ...type }))),
+    },
+    addresses: {
+      toArray: vi.fn(async () => addressesStore.map((address) => ({ ...address }))),
+      put: vi.fn(async (address: Address) => {
+        const id = typeof address.id === 'number' ? address.id : nextNumericId(addressesStore);
+        const record: Address = { id, ...address };
+        const index = addressesStore.findIndex((item) => item.id === id);
+        if (index >= 0) {
+          addressesStore[index] = record;
+        } else {
+          addressesStore.push(record);
+        }
+        return id;
+      }),
+    },
+  };
+
+  return { territoriesStore, streetsStore, propertyTypesStore, addressesStore, dbMock };
+});
+
+vi.mock('../services/db', () => ({
+  db: dbMock,
+}));
+
+vi.mock('../components/ImageAnnotator', () => ({
+  __esModule: true,
+  default: ({
+    onAdd,
+    onUpdate,
+    onDelete,
+  }: {
+    onAdd?: () => void;
+    onUpdate?: () => void;
+    onDelete?: () => void;
+  }) => (
+    <div>
+      <button type="button" data-testid="annotator-add" onClick={() => onAdd?.()}>
+        Annotator Add
+      </button>
+      <button type="button" data-testid="annotator-update" onClick={() => onUpdate?.()}>
+        Annotator Update
+      </button>
+      <button type="button" data-testid="annotator-delete" onClick={() => onDelete?.()}>
+        Annotator Delete
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('react-hook-form', () => ({
+  useForm: () => {
+    const values: Partial<AddressForm> = {};
+
+    const register = (name: keyof AddressForm) => {
+      const handler = (event: Event) => {
+        const target = event.target as HTMLInputElement | HTMLSelectElement;
+        values[name] = target.value as never;
+      };
+
+      return {
+        name,
+        onChange: handler,
+        onInput: handler,
+      };
+    };
+
+    const toNumber = (value: unknown): number => {
+      return value === undefined || value === '' ? NaN : Number(value);
+    };
+
+    const handleSubmit = (callback: (data: AddressForm) => unknown) => async (event?: Event) => {
+      event?.preventDefault();
+      await callback({
+        streetId: toNumber(values.streetId),
+        propertyTypeId: toNumber(values.propertyTypeId),
+        numberStart: toNumber(values.numberStart),
+        numberEnd: toNumber(values.numberEnd),
+        id: values.id === undefined ? undefined : toNumber(values.id),
+      });
+    };
+
+    const reset = () => {
+      Object.keys(values).forEach((key) => {
+        values[key as keyof AddressForm] = undefined as never;
+      });
+    };
+
+    return { register, handleSubmit, reset };
+  },
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (options?.count !== undefined) {
+        return `${key} (${options.count})`;
+      }
+      return key;
+    },
+  }),
+}));
+
+import RuasNumeracoesPage from './RuasNumeracoesPage';
+
+const baseTerritories: Territorio[] = [
+  { id: 'territorio-1', nome: 'Território 1', imageUrl: 'image-1.png' },
+  { id: 'territorio-2', nome: 'Território 2', imageUrl: 'image-2.png' },
+];
+
+const baseStreets: Street[] = [
+  { id: 1, territoryId: 'territorio-1', name: 'Rua Principal' },
+  { id: 2, territoryId: 'territorio-2', name: 'Avenida Secundária' },
+];
+
+const basePropertyTypes: PropertyType[] = [
+  { id: 10, name: 'Casa' },
+  { id: 20, name: 'Apartamento' },
+];
+
+const baseAddresses: Address[] = [
+  { id: 5, streetId: 1, numberStart: 1, numberEnd: 10, propertyTypeId: 10 },
+];
+
+beforeEach(() => {
+  territoriesStore.splice(0, territoriesStore.length, ...baseTerritories.map((territory) => ({ ...territory })));
+  streetsStore.splice(0, streetsStore.length, ...baseStreets.map((street) => ({ ...street })));
+  propertyTypesStore.splice(
+    0,
+    propertyTypesStore.length,
+    ...basePropertyTypes.map((type) => ({ ...type })),
+  );
+  addressesStore.splice(0, addressesStore.length, ...baseAddresses.map((address) => ({ ...address })));
+
+  dbMock.territorios.toArray.mockClear();
+  dbMock.streets.toArray.mockClear();
+  dbMock.streets.put.mockClear();
+  dbMock.propertyTypes.toArray.mockClear();
+  dbMock.addresses.toArray.mockClear();
+  dbMock.addresses.put.mockClear();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('RuasNumeracoesPage', () => {
+  it('loads data from the database and filters streets by territory', async () => {
+    render(<RuasNumeracoesPage />);
+
+    await waitFor(() => {
+      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(dbMock.streets.toArray).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Rua Principal')).toBeTruthy();
+    });
+
+    expect(screen.queryByText('Avenida Secundária')).toBeNull();
+    const streetsTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.streets' });
+    expect(streetsTab.className).toContain('font-bold');
+  });
+
+  it('adds a new street for the active territory', async () => {
+    render(<RuasNumeracoesPage />);
+
+    await waitFor(() => {
+      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(dbMock.streets.toArray).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Rua Principal')).toBeTruthy();
+    });
+
+    const input = screen.getByPlaceholderText(
+      'ruasNumeracoes.streetsForm.streetNamePlaceholder',
+    ) as HTMLInputElement;
+    input.value = 'Nova Rua';
+
+    const form = input.closest('form');
+    expect(form).toBeTruthy();
+
+    await act(async () => {
+      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Nova Rua')).toBeTruthy();
+    });
+
+    expect(dbMock.streets.put).toHaveBeenCalledWith({
+      territoryId: 'territorio-1',
+      name: 'Nova Rua',
+    });
+  });
+
+  it('focuses the addresses tab via annotator callbacks and saves new addresses', async () => {
+    render(<RuasNumeracoesPage />);
+
+    await waitFor(() => {
+      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(dbMock.streets.toArray).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Rua Principal')).toBeTruthy();
+    });
+
+    const streetsTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.streets' });
+    const addressesTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.addresses' });
+
+    expect(streetsTab.className).toContain('font-bold');
+
+    await act(async () => {
+      screen.getByTestId('annotator-add').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(addressesTab.className).toContain('font-bold');
+
+    await act(async () => {
+      streetsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(streetsTab.className).toContain('font-bold');
+
+    await act(async () => {
+      screen.getByTestId('annotator-update').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(addressesTab.className).toContain('font-bold');
+
+    await act(async () => {
+      streetsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(streetsTab.className).toContain('font-bold');
+
+    await act(async () => {
+      screen.getByTestId('annotator-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    });
+    expect(addressesTab.className).toContain('font-bold');
+
+    const selects = screen.getAllByRole('combobox');
+    const streetSelect = selects[0] as HTMLSelectElement;
+    const propertyTypeSelect = selects[1] as HTMLSelectElement;
+
+    await act(async () => {
+      streetSelect.value = '1';
+      streetSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await act(async () => {
+      propertyTypeSelect.value = '10';
+      propertyTypeSelect.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const numberStartInput = screen.getByPlaceholderText(
+      'ruasNumeracoes.addressesForm.numberStart',
+    ) as HTMLInputElement;
+    const numberEndInput = screen.getByPlaceholderText(
+      'ruasNumeracoes.addressesForm.numberEnd',
+    ) as HTMLInputElement;
+
+    await act(async () => {
+      numberStartInput.value = '100';
+      numberStartInput.dispatchEvent(new Event('input', { bubbles: true }));
+      numberStartInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    await act(async () => {
+      numberEndInput.value = '200';
+      numberEndInput.dispatchEvent(new Event('input', { bubbles: true }));
+      numberEndInput.dispatchEvent(new Event('change', { bubbles: true }));
+    });
+
+    const saveButton = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement;
+
+    await act(async () => {
+      saveButton.click();
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(dbMock.addresses.put).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('200')).toBeTruthy();
+    });
+
+    expect(dbMock.addresses.put).toHaveBeenCalledWith({
+      streetId: 1,
+      propertyTypeId: 10,
+      numberStart: 100,
+      numberEnd: 200,
+    });
+  });
+});

--- a/src/services/repositories/repositories.test.ts
+++ b/src/services/repositories/repositories.test.ts
@@ -57,6 +57,19 @@ describe('TerritorioRepository', () => {
     expect(stored).toHaveLength(1);
     expect(stored[0]).toEqual(territorios[1]);
   });
+
+  it('clears all territorios', async () => {
+    const territorios: Territorio[] = [
+      { id: 'territorio-1', nome: 'Territory 1' },
+      { id: 'territorio-2', nome: 'Territory 2' }
+    ];
+
+    await TerritorioRepository.bulkAdd(territorios);
+    await TerritorioRepository.clear();
+    const stored = await TerritorioRepository.all();
+
+    expect(stored).toEqual([]);
+  });
 });
 
 describe('SaidaRepository', () => {

--- a/test-utils/testing-library-react.tsx
+++ b/test-utils/testing-library-react.tsx
@@ -1,0 +1,253 @@
+import type { ReactElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { act as reactAct } from 'react';
+
+if (typeof globalThis !== 'undefined') {
+  (globalThis as Record<string, unknown>).IS_REACT_ACT_ENVIRONMENT = true;
+}
+
+export const act = reactAct;
+
+interface MountedContainer {
+  container: HTMLElement;
+  root: Root;
+}
+
+const mountedContainers = new Set<MountedContainer>();
+
+function cleanupContainer(entry: MountedContainer): void {
+  if (!mountedContainers.has(entry)) {
+    return;
+  }
+
+  reactAct(() => {
+    entry.root.unmount();
+  });
+
+  if (entry.container.parentNode) {
+    entry.container.parentNode.removeChild(entry.container);
+  }
+
+  mountedContainers.delete(entry);
+}
+
+export function cleanup(): void {
+  for (const entry of Array.from(mountedContainers)) {
+    cleanupContainer(entry);
+  }
+}
+
+export interface RenderResult {
+  container: HTMLElement;
+  rerender: (ui: ReactElement) => void;
+  unmount: () => void;
+}
+
+export function render(ui: ReactElement): RenderResult {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+
+  const root = createRoot(container);
+  const entry: MountedContainer = { container, root };
+  mountedContainers.add(entry);
+
+  reactAct(() => {
+    root.render(ui);
+  });
+
+  return {
+    container,
+    rerender: (nextUi: ReactElement) => {
+      reactAct(() => {
+        root.render(nextUi);
+      });
+    },
+    unmount: () => {
+      cleanupContainer(entry);
+    },
+  };
+}
+
+type TextMatcher = string | RegExp;
+
+function matchText(content: string, matcher?: TextMatcher): boolean {
+  if (matcher === undefined) {
+    return true;
+  }
+
+  if (typeof matcher === 'string') {
+    return content.trim() === matcher;
+  }
+
+  return matcher.test(content);
+}
+
+function getElementText(element: Element): string {
+  return element.textContent?.trim() ?? '';
+}
+
+function queryAllByText(container: HTMLElement, matcher: TextMatcher): HTMLElement[] {
+  const elements = Array.from(container.querySelectorAll<HTMLElement>('*'));
+  return elements.filter((element) => matchText(getElementText(element), matcher));
+}
+
+function getByText(container: HTMLElement, matcher: TextMatcher): HTMLElement {
+  const matches = queryAllByText(container, matcher);
+  if (matches.length === 0) {
+    throw new Error(`Unable to find an element with text: ${String(matcher)}`);
+  }
+  return matches[0];
+}
+
+function queryByText(container: HTMLElement, matcher: TextMatcher): HTMLElement | null {
+  const matches = queryAllByText(container, matcher);
+  return matches[0] ?? null;
+}
+
+function getRole(element: Element): string | null {
+  const explicitRole = element.getAttribute('role');
+  if (explicitRole) {
+    return explicitRole;
+  }
+
+  switch (element.tagName.toLowerCase()) {
+    case 'button':
+      return 'button';
+    case 'select':
+      return 'combobox';
+    case 'input': {
+      const type = (element as HTMLInputElement).type;
+      if (type === 'number') {
+        return 'spinbutton';
+      }
+      return 'textbox';
+    }
+    default:
+      return null;
+  }
+}
+
+interface RoleOptions {
+  name?: TextMatcher;
+}
+
+function queryAllByRole(container: HTMLElement, role: string, options?: RoleOptions): HTMLElement[] {
+  const elements = Array.from(container.querySelectorAll<HTMLElement>('*'));
+  return elements.filter((element) => {
+    const elementRole = getRole(element);
+    if (elementRole !== role) {
+      return false;
+    }
+
+    if (options?.name !== undefined) {
+      return matchText(getElementText(element), options.name);
+    }
+
+    return true;
+  });
+}
+
+function getAllByRole(container: HTMLElement, role: string, options?: RoleOptions): HTMLElement[] {
+  const matches = queryAllByRole(container, role, options);
+  if (matches.length === 0) {
+    throw new Error(`Unable to find an element with role: ${role}`);
+  }
+  return matches;
+}
+
+function getByRole(container: HTMLElement, role: string, options?: RoleOptions): HTMLElement {
+  const matches = getAllByRole(container, role, options);
+  return matches[0];
+}
+
+function queryByRole(container: HTMLElement, role: string, options?: RoleOptions): HTMLElement | null {
+  const matches = queryAllByRole(container, role, options);
+  return matches[0] ?? null;
+}
+
+function getByPlaceholderText(container: HTMLElement, matcher: TextMatcher): HTMLElement {
+  const elements = Array.from(container.querySelectorAll<HTMLElement>('[placeholder]'));
+  for (const element of elements) {
+    const placeholder = element.getAttribute('placeholder') ?? '';
+    if (matchText(placeholder, matcher)) {
+      return element;
+    }
+  }
+  throw new Error(`Unable to find an element with placeholder: ${String(matcher)}`);
+}
+
+function escapeTestId(value: string): string {
+  return value.replace(/"/g, '\\"');
+}
+
+function getByTestId(container: HTMLElement, testId: string): HTMLElement {
+  const selector = `[data-testid="${escapeTestId(testId)}"]`;
+  const element = container.querySelector<HTMLElement>(selector);
+  if (!element) {
+    throw new Error(`Unable to find an element with test id: ${testId}`);
+  }
+  return element;
+}
+
+export const screen = {
+  getByText: (matcher: TextMatcher) => getByText(document.body, matcher),
+  queryByText: (matcher: TextMatcher) => queryByText(document.body, matcher),
+  getByRole: (role: string, options?: RoleOptions) => getByRole(document.body, role, options),
+  queryByRole: (role: string, options?: RoleOptions) => queryByRole(document.body, role, options),
+  getAllByRole: (role: string, options?: RoleOptions) => getAllByRole(document.body, role, options),
+  getByPlaceholderText: (matcher: TextMatcher) => getByPlaceholderText(document.body, matcher),
+  getByTestId: (testId: string) => getByTestId(document.body, testId),
+};
+
+interface WaitForOptions {
+  timeout?: number;
+  interval?: number;
+}
+
+export async function waitFor<T>(callback: () => T | Promise<T>, options: WaitForOptions = {}): Promise<T> {
+  const { timeout = 1000, interval = 16 } = options;
+  const endTime = Date.now() + timeout;
+  let lastError: unknown;
+
+  while (Date.now() < endTime) {
+    try {
+      let callbackResult: T | undefined;
+      await reactAct(async () => {
+        callbackResult = await callback();
+      });
+      return callbackResult as T;
+    } catch (error) {
+      lastError = error;
+      await new Promise((resolve) => setTimeout(resolve, interval));
+    }
+  }
+
+  throw lastError ?? new Error('Timed out in waitFor.');
+}
+
+export interface RenderHookResult<T> {
+  result: { current: T };
+  rerender: () => void;
+  unmount: () => void;
+}
+
+export function renderHook<T>(callback: () => T): RenderHookResult<T> {
+  const result: { current: T } = {
+    current: undefined as unknown as T,
+  };
+
+  function HookWrapper(): null {
+    result.current = callback();
+    return null;
+  }
+
+  const renderResult = render(<HookWrapper />);
+
+  return {
+    result,
+    rerender: () => {
+      renderResult.rerender(<HookWrapper />);
+    },
+    unmount: renderResult.unmount,
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,8 +1,16 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import { fileURLToPath, URL } from 'node:url';
 
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@testing-library/react': fileURLToPath(
+        new URL('./test-utils/testing-library-react.tsx', import.meta.url),
+      ),
+    },
+  },
   test: {
     environment: 'jsdom',
   },


### PR DESCRIPTION
## Summary
- create a light-weight test utilities module and wire it as the @testing-library/react alias
- cover useTerritorios and the RuasNumeracoes page with new unit and interface tests
- extend repository coverage and add a CI workflow that runs vitest on every push and PR

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68c9af64362883259b936e204dd89318