### PR TITLE
Localize theme toggle labels

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -1,4 +1,5 @@
 import React, { useLayoutEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
 
 interface ShellProps {
@@ -6,6 +7,7 @@ interface ShellProps {
 }
 
 export const Shell: React.FC<ShellProps> = ({ children }) => {
+  const { t } = useTranslation();
   const [dark, setDark] = useState<boolean>(() => {
     const stored = localStorage.getItem('dark');
     if (stored !== null) return JSON.parse(stored) as boolean;
@@ -28,7 +30,7 @@ export const Shell: React.FC<ShellProps> = ({ children }) => {
             <h1 className="font-bold tracking-tight">Territory Manager</h1>
             <div className="flex items-center gap-2">
               <button onClick={() => setDark((value) => !value)} className="rounded-xl px-3 py-2 border">
-                {dark ? '☀️ Claro' : '🌙 Escuro'}
+                {dark ? `☀️ ${t('app.theme.light')}` : `🌙 ${t('app.theme.dark')}`}
               </button>
             </div>
           </div>

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -287,7 +287,11 @@
     "importError": "Unable to import data",
     "clearConfirm": "Clear ALL data?",
     "clearSuccess": "Data cleared",
-    "clearError": "Unable to clear data"
+    "clearError": "Unable to clear data",
+    "theme": {
+      "light": "Light theme",
+      "dark": "Dark theme"
+    }
   },
   "language": {
     "english": "English",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -286,7 +286,11 @@
     "importError": "No se pudieron importar los datos",
     "clearConfirm": "¿Borrar TODOS los datos?",
     "clearSuccess": "Datos borrados",
-    "clearError": "No se pudieron borrar los datos"
+    "clearError": "No se pudieron borrar los datos",
+    "theme": {
+      "light": "Tema claro",
+      "dark": "Tema oscuro"
+    }
   },
   "language": {
     "english": "Inglés",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -289,7 +289,11 @@
     "importError": "Não foi possível importar os dados",
     "clearConfirm": "Limpar TODOS os dados?",
     "clearSuccess": "Dados limpos",
-    "clearError": "Não foi possível limpar os dados"
+    "clearError": "Não foi possível limpar os dados",
+    "theme": {
+      "light": "Tema claro",
+      "dark": "Tema escuro"
+    }
   },
   "language": {
     "english": "Inglês",


### PR DESCRIPTION
## Summary
- use i18n translations for the theme toggle button in the shell layout
- add light and dark theme labels to every locale so the toggle updates with the selected language

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68c9b97b30a88325aff8b0f707ea4695