### PR TITLE
Add language selector to shell header

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -1,6 +1,7 @@
 import React, { useLayoutEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sidebar } from './Sidebar';
+import { LanguageSelector } from '../forms/LanguageSelector';
 
 interface ShellProps {
   children: React.ReactNode;
@@ -29,6 +30,7 @@ export const Shell: React.FC<ShellProps> = ({ children }) => {
           <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between">
             <h1 className="font-bold tracking-tight">Territory Manager</h1>
             <div className="flex items-center gap-2">
+              <LanguageSelector />
               <button onClick={() => setDark((value) => !value)} className="rounded-xl px-3 py-2 border">
                 {dark ? `☀️ ${t('app.theme.light')}` : `🌙 ${t('app.theme.dark')}`}
               </button>


### PR DESCRIPTION
## Summary
- import the language selector into the app shell header
- render the language selector alongside the existing theme toggle controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9bb2f70608325a5d11c88911c1412