### PR TITLE
Fix Portuguese language label

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -295,7 +295,7 @@
   },
   "language": {
     "english": "English",
-    "portuguese": "PortuguǦs",
+    "portuguese": "Portuguese",
     "spanish": "Spanish"
   },
   "common": {


### PR DESCRIPTION
## Summary
- correct the Portuguese language label in the English translation file

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c9bdb9099c8325b2398f1bd73e338e