### PR TITLE
Add territory selector for Ruas Numeracoes page

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -130,6 +130,10 @@
       "addresses": "Addresses",
       "summary": "Summary"
     },
+    "territorySelector": {
+      "label": "Territory",
+      "placeholder": "Select a territory"
+    },
     "streetsForm": {
       "streetNamePlaceholder": "Street name"
     },

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -129,6 +129,10 @@
       "addresses": "Direcciones",
       "summary": "Resumen"
     },
+    "territorySelector": {
+      "label": "Territorio",
+      "placeholder": "Selecciona un territorio"
+    },
     "streetsForm": {
       "streetNamePlaceholder": "Nombre de la calle"
     },

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -131,6 +131,10 @@
       "addresses": "Endereços",
       "summary": "Resumo"
     },
+    "territorySelector": {
+      "label": "Território",
+      "placeholder": "Selecione um território"
+    },
     "streetsForm": {
       "streetNamePlaceholder": "Nome da rua"
     },


### PR DESCRIPTION
## Summary
- add a territory selector to the Ruas & Numerações page so the active territory can be switched
- refresh territory streets and addresses whenever the selection changes and handle empty territory lists
- supply translations for the new selector in all supported locales

## Testing
- npm run lint *(fails: existing lint error in src/services/db.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c9c46547748325810089d00fc0f989