### PR TITLE
Add correspondence tracking UI and data updates

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,7 @@ import { Shell } from './components/layout/Shell';
 import TerritoriesPage from './pages/TerritoriesPage';
 import StreetsPage from './pages/RuasNumeracoesPage';
 import BuildingsVillagesPage from './pages/PrediosVilas';
+import CartasPage from './pages/CartasPage';
 import ExitsPage from './pages/ExitsPage';
 import AssignmentsPage from './pages/AssignmentsPage';
 import CalendarPage from './pages/CalendarPage';
@@ -35,6 +36,7 @@ const pagesByTab: Record<TabKey, ComponentType> = {
   territories: TerritoriesPage,
   streets: StreetsPage,
   buildingsVillages: BuildingsVillagesPage,
+  letters: CartasPage,
   exits: ExitsPage,
   assignments: AssignmentsPage,
   calendar: CalendarPage,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -56,6 +56,13 @@ const BuildingIcon = () => (
   </svg>
 );
 
+const LetterIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
+    <rect x="3" y="5" width="18" height="14" rx="2" />
+    <path d="M3 7l9 6 9-6" />
+  </svg>
+);
+
 const HomeOffIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M3 9l9-6 9 6" />
@@ -69,6 +76,7 @@ const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
   { id: 'territories', label: 'sidebar.territories', icon: <MapIcon /> },
   { id: 'streets', label: 'sidebar.streets', icon: <MapIcon /> },
   { id: 'buildingsVillages', label: 'sidebar.buildingsVillages', icon: <BuildingIcon /> },
+  { id: 'letters', label: 'sidebar.letters', icon: <LetterIcon /> },
   { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
   { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
   { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -43,6 +43,7 @@
     "territories": "Territories",
     "streets": "Streets",
     "buildingsVillages": "Buildings & Villages",
+    "letters": "Letters",
     "exits": "Exits",
     "assignments": "Assignments",
     "calendar": "Calendar",
@@ -115,6 +116,9 @@
       "reception": "Reception type",
       "residences": "Number of residences",
       "responsible": "Responsible person",
+      "contactMethod": "Contact method",
+      "letterStatus": "Letter status",
+      "letterHistory": "Correspondence history",
       "assignedAt": "Assigned on",
       "returnedAt": "Returned on",
       "block": "Block",
@@ -129,8 +133,25 @@
       "modality": "Condominium, gated community...",
       "reception": "Reception desk, intercom...",
       "responsible": "Name of the superintendent, doorman...",
+      "contactMethod": "Phone, email, concierge...",
       "block": "Block identification",
       "notes": "Relevant details, schedules, access instructions..."
+    },
+    "letterStatus": {
+      "notSent": "No letter sent",
+      "inProgress": "Correspondence in progress",
+      "sent": "Letter sent",
+      "responded": "Response received",
+      "unknown": "Status unknown"
+    },
+    "letterHistory": {
+      "add": "Add entry",
+      "empty": "No correspondence recorded yet.",
+      "sentAt": "Sent on",
+      "status": "Status",
+      "remove": "Remove",
+      "notes": "Notes",
+      "notesPlaceholder": "Summary, follow-up, reply details..."
     },
     "modal": {
       "editTitle": "Edit record",
@@ -152,6 +173,24 @@
       "saveError": "Could not save the record"
     },
     "confirmDelete": "Do you really want to remove this record?"
+  },
+
+  "letters": {
+    "title": "Letters",
+    "subtitle": "Review correspondence sent and responses grouped by responsible person.",
+    "summary": "Responsibles tracked: {{responsibles}} • Letters recorded: {{letters}}",
+    "loading": "Loading correspondence...",
+    "empty": "No correspondence has been recorded yet.",
+    "feedback": {
+      "loadError": "Failed to load correspondence data"
+    },
+    "groupSummary": "Letters recorded: {{letters}} • Properties: {{buildings}}",
+    "contactMethods": "Contact methods: {{methods}}",
+    "contactMethod": "Preferred contact",
+    "history": "History",
+    "noHistory": "No letters recorded for this property.",
+    "unnamedBuilding": "Unnamed building/village",
+    "unknownTerritory": "Territory unknown"
   },
     "ruasNumeracoes": {
     "tabs": {

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -43,6 +43,7 @@
     "territories": "Territorios",
     "streets": "Calles",
     "buildingsVillages": "Edificios y Villas",
+    "letters": "Correspondencia",
     "exits": "Salidas",
     "assignments": "Asignaciones",
     "calendar": "Calendario",
@@ -114,6 +115,9 @@
       "reception": "Tipo de recepción",
       "residences": "Cantidad de residencias",
       "responsible": "Responsable",
+      "contactMethod": "Método de contacto",
+      "letterStatus": "Estado de la correspondencia",
+      "letterHistory": "Historial de correspondencia",
       "assignedAt": "Asignado el",
       "returnedAt": "Devuelto el",
       "block": "Bloque",
@@ -128,8 +132,25 @@
       "modality": "Condominio, villa cerrada...",
       "reception": "Portería, intercomunicador...",
       "responsible": "Nombre del síndico, portero...",
+      "contactMethod": "Teléfono, correo, portería...",
       "block": "Identificación del bloque",
       "notes": "Detalles relevantes, horarios, instrucciones de acceso..."
+    },
+    "letterStatus": {
+      "notSent": "Ninguna carta enviada",
+      "inProgress": "Correspondencia en curso",
+      "sent": "Carta enviada",
+      "responded": "Respuesta recibida",
+      "unknown": "Estado desconocido"
+    },
+    "letterHistory": {
+      "add": "Agregar registro",
+      "empty": "No se ha registrado correspondencia.",
+      "sentAt": "Fecha de envío",
+      "status": "Estado",
+      "remove": "Eliminar",
+      "notes": "Notas",
+      "notesPlaceholder": "Resumen, respuesta, detalles de seguimiento..."
     },
     "modal": {
       "editTitle": "Editar registro",
@@ -151,6 +172,23 @@
       "saveError": "No se pudo guardar el registro"
     },
     "confirmDelete": "¿Desea realmente eliminar este registro?"
+  },
+  "letters": {
+    "title": "Correspondencia",
+    "subtitle": "Revisa cartas enviadas y respuestas agrupadas por responsable.",
+    "summary": "Responsables registrados: {{responsibles}} • Cartas registradas: {{letters}}",
+    "loading": "Cargando correspondencia...",
+    "empty": "Aún no se ha registrado correspondencia.",
+    "feedback": {
+      "loadError": "No se pudo cargar la correspondencia"
+    },
+    "groupSummary": "Cartas registradas: {{letters}} • Propiedades: {{buildings}}",
+    "contactMethods": "Métodos de contacto: {{methods}}",
+    "contactMethod": "Contacto preferido",
+    "history": "Historial",
+    "noHistory": "No hay cartas registradas para esta propiedad.",
+    "unnamedBuilding": "Edificio/Villa sin nombre",
+    "unknownTerritory": "Territorio desconocido"
   },
   "ruasNumeracoes": {
     "tabs": {

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -43,6 +43,7 @@
     "territories": "Territórios",
     "streets": "Ruas",
     "buildingsVillages": "Prédios & Vilas",
+    "letters": "Cartas",
     "exits": "Saídas",
     "assignments": "Designações",
     "calendar": "Calendário",
@@ -115,6 +116,9 @@
       "reception": "Tipo de recepção",
       "residences": "Quantidade de residências",
       "responsible": "Responsável",
+      "contactMethod": "Método de contato",
+      "letterStatus": "Status da correspondência",
+      "letterHistory": "Histórico de correspondências",
       "assignedAt": "Designado em",
       "returnedAt": "Devolvido em",
       "block": "Bloco",
@@ -129,8 +133,25 @@
       "modality": "Condomínio, vila fechada...",
       "reception": "Portaria, interfone...",
       "responsible": "Nome do síndico, porteiro...",
+      "contactMethod": "Telefone, e-mail, portaria...",
       "block": "Identificação do bloco",
       "notes": "Detalhes relevantes, horários, instruções de acesso..."
+    },
+    "letterStatus": {
+      "notSent": "Nenhuma carta enviada",
+      "inProgress": "Correspondência em andamento",
+      "sent": "Carta enviada",
+      "responded": "Resposta recebida",
+      "unknown": "Status não informado"
+    },
+    "letterHistory": {
+      "add": "Adicionar registro",
+      "empty": "Nenhuma correspondência registrada.",
+      "sentAt": "Data de envio",
+      "status": "Status",
+      "remove": "Remover",
+      "notes": "Anotações",
+      "notesPlaceholder": "Resumo do conteúdo, resposta recebida..."
     },
     "modal": {
       "editTitle": "Editar registro",
@@ -152,6 +173,24 @@
       "saveError": "Não foi possível salvar o registro"
     },
     "confirmDelete": "Deseja realmente remover este registro?"
+  },
+
+  "letters": {
+    "title": "Correspondências",
+    "subtitle": "Acompanhe cartas enviadas e respostas por responsável.",
+    "summary": "Responsáveis acompanhados: {{responsibles}} • Cartas registradas: {{letters}}",
+    "loading": "Carregando correspondências...",
+    "empty": "Nenhuma correspondência registrada até o momento.",
+    "feedback": {
+      "loadError": "Não foi possível carregar as correspondências"
+    },
+    "groupSummary": "Cartas registradas: {{letters}} • Imóveis: {{buildings}}",
+    "contactMethods": "Métodos de contato: {{methods}}",
+    "contactMethod": "Contato preferencial",
+    "history": "Histórico",
+    "noHistory": "Nenhuma carta registrada para este imóvel.",
+    "unnamedBuilding": "Prédio/Vila sem nome",
+    "unknownTerritory": "Território não identificado"
   },
     
   "ruasNumeracoes": {

--- a/src/pages/CartasPage.tsx
+++ b/src/pages/CartasPage.tsx
@@ -1,0 +1,294 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import {
+  type BuildingVillage,
+  type BuildingVillageLetterHistoryEntry,
+  type BuildingVillageLetterStatus
+} from '../types/building_village';
+import type { Territorio } from '../types/territorio';
+import { BuildingVillageRepository } from '../services/repositories/buildings_villages';
+import { TerritorioRepository } from '../services/repositories/territorios';
+import { useToast } from '../components/feedback/Toast';
+
+const letterStatusTranslationKeys: Record<BuildingVillageLetterStatus, string> = {
+  not_sent: 'buildingsVillages.letterStatus.notSent',
+  in_progress: 'buildingsVillages.letterStatus.inProgress',
+  sent: 'buildingsVillages.letterStatus.sent',
+  responded: 'buildingsVillages.letterStatus.responded'
+};
+
+const formatDate = (value: string | null) => {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleDateString();
+};
+
+const sortLetterHistory = (
+  history: BuildingVillageLetterHistoryEntry[]
+): BuildingVillageLetterHistoryEntry[] => {
+  return [...history].sort((a, b) => {
+    const aDate = a.sent_at ?? '';
+    const bDate = b.sent_at ?? '';
+    return bDate.localeCompare(aDate);
+  });
+};
+
+type ResponsibleGroupEntry = {
+  buildingId: string;
+  buildingName: string | null;
+  territoryId: string;
+  contactMethod: string | null;
+  letterStatus: BuildingVillageLetterStatus | null;
+  letterHistory: BuildingVillageLetterHistoryEntry[];
+};
+
+type ResponsibleGroup = {
+  responsible: string;
+  contactMethods: string[];
+  lettersCount: number;
+  entries: ResponsibleGroupEntry[];
+};
+
+const getLetterStatusLabel = (
+  status: BuildingVillageLetterStatus | null | undefined,
+  t: ReturnType<typeof useTranslation>['t']
+) => {
+  if (!status) {
+    return t('buildingsVillages.letterStatus.unknown');
+  }
+  return t(letterStatusTranslationKeys[status]);
+};
+
+const CartasPage: React.FC = () => {
+  const [villages, setVillages] = useState<BuildingVillage[]>([]);
+  const [territories, setTerritories] = useState<Territorio[]>([]);
+  const [loading, setLoading] = useState(true);
+  const toast = useToast();
+  const { t } = useTranslation();
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        setLoading(true);
+        const [villagesData, territoriesData] = await Promise.all([
+          BuildingVillageRepository.all(),
+          TerritorioRepository.all()
+        ]);
+        setVillages(villagesData);
+        setTerritories(territoriesData);
+      } catch (error) {
+        console.error(error);
+        toast.error(t('letters.feedback.loadError'));
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    void load();
+  }, [toast, t]);
+
+  const territoryNameById = useMemo(() => {
+    return territories.reduce<Record<string, string>>((acc, territory) => {
+      acc[territory.id] = territory.nome;
+      return acc;
+    }, {});
+  }, [territories]);
+
+  const groups = useMemo<ResponsibleGroup[]>(() => {
+    const map = new Map<string, ResponsibleGroup>();
+
+    villages.forEach((building) => {
+      const responsibleRaw = building.responsible?.trim();
+      if (!responsibleRaw) {
+        return;
+      }
+
+      const history = Array.isArray(building.letter_history) ? building.letter_history : [];
+      const hasHistory = history.length > 0;
+      const hasStatus = Boolean(building.letter_status);
+
+      if (!hasHistory && !hasStatus) {
+        return;
+      }
+
+      const group = map.get(responsibleRaw) ?? {
+        responsible: responsibleRaw,
+        contactMethods: [],
+        lettersCount: 0,
+        entries: []
+      };
+
+      group.entries.push({
+        buildingId: building.id,
+        buildingName: building.name ?? null,
+        territoryId: building.territory_id,
+        contactMethod: building.contact_method,
+        letterStatus: building.letter_status ?? null,
+        letterHistory: history
+      });
+
+      if (building.contact_method) {
+        const method = building.contact_method.trim();
+        if (method.length > 0 && !group.contactMethods.includes(method)) {
+          group.contactMethods.push(method);
+        }
+      }
+
+      group.lettersCount += history.length;
+
+      map.set(responsibleRaw, group);
+    });
+
+    return Array.from(map.values())
+      .map((group) => ({
+        ...group,
+        contactMethods: group.contactMethods.sort((a, b) => a.localeCompare(b)),
+        entries: group.entries.sort((a, b) => {
+          const nameA = a.buildingName ?? '';
+          const nameB = b.buildingName ?? '';
+          return nameA.localeCompare(nameB);
+        })
+      }))
+      .sort((a, b) => a.responsible.localeCompare(b.responsible));
+  }, [villages]);
+
+  const totalLetters = useMemo(
+    () => groups.reduce((sum, group) => sum + group.lettersCount, 0),
+    [groups]
+  );
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-2xl font-semibold">{t('letters.title')}</h1>
+        <p className="text-sm text-neutral-500 dark:text-neutral-400">{t('letters.subtitle')}</p>
+      </header>
+
+      <section className="rounded-2xl border border-black/5 bg-white/70 p-4 shadow backdrop-blur dark:border-white/10 dark:bg-neutral-900/60">
+        <p className="text-sm text-neutral-600 dark:text-neutral-300">
+          {t('letters.summary', { responsibles: groups.length, letters: totalLetters })}
+        </p>
+      </section>
+
+      {loading ? (
+        <div className="rounded-2xl border border-dashed border-black/10 p-8 text-center text-sm text-neutral-500 dark:border-white/10 dark:text-neutral-400">
+          {t('letters.loading')}
+        </div>
+      ) : groups.length === 0 ? (
+        <div className="rounded-2xl border border-dashed border-black/10 p-8 text-center text-sm text-neutral-500 dark:border-white/10 dark:text-neutral-400">
+          {t('letters.empty')}
+        </div>
+      ) : (
+        <div className="space-y-6">
+          {groups.map((group) => (
+            <section
+              key={group.responsible}
+              className="space-y-3 rounded-2xl border border-black/5 bg-white/80 p-4 shadow-sm backdrop-blur dark:border-white/10 dark:bg-neutral-900/70"
+            >
+              <header className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                <div>
+                  <h2 className="text-xl font-semibold text-neutral-900 dark:text-neutral-100">
+                    {group.responsible}
+                  </h2>
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    {t('letters.groupSummary', {
+                      letters: group.lettersCount,
+                      buildings: group.entries.length
+                    })}
+                  </p>
+                </div>
+                {group.contactMethods.length > 0 && (
+                  <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                    {t('letters.contactMethods', {
+                      methods: group.contactMethods.join(', ')
+                    })}
+                  </p>
+                )}
+              </header>
+
+              <div className="space-y-3">
+                {group.entries.map((entry) => (
+                  <article
+                    key={entry.buildingId}
+                    className="space-y-2 rounded-xl border border-black/5 p-3 shadow-sm dark:border-white/10 dark:bg-neutral-950/50"
+                  >
+                    <header className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:justify-between">
+                      <div>
+                        <h3 className="text-lg font-medium text-neutral-900 dark:text-neutral-100">
+                          {entry.buildingName || t('letters.unnamedBuilding')}
+                        </h3>
+                        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+                          {territoryNameById[entry.territoryId] ?? t('letters.unknownTerritory')}
+                        </p>
+                      </div>
+                      {entry.letterStatus && (
+                        <span className="inline-flex items-center justify-center rounded-full bg-blue-50 px-3 py-1 text-xs font-medium text-blue-700 dark:bg-blue-500/20 dark:text-blue-200">
+                          {getLetterStatusLabel(entry.letterStatus, t)}
+                        </span>
+                      )}
+                    </header>
+
+                    <dl className="space-y-1 text-xs text-neutral-600 dark:text-neutral-300">
+                      {entry.contactMethod && (
+                        <div>
+                          <dt className="font-medium text-neutral-500 dark:text-neutral-400">
+                            {t('letters.contactMethod')}
+                          </dt>
+                          <dd>{entry.contactMethod}</dd>
+                        </div>
+                      )}
+                      {entry.letterHistory.length === 0 ? (
+                        <div>
+                          <dt className="font-medium text-neutral-500 dark:text-neutral-400">
+                            {t('letters.history')}
+                          </dt>
+                          <dd>{t('letters.noHistory')}</dd>
+                        </div>
+                      ) : (
+                        <div>
+                          <dt className="font-medium text-neutral-500 dark:text-neutral-400">
+                            {t('letters.history')}
+                          </dt>
+                          <dd>
+                            <ul className="space-y-1">
+                              {sortLetterHistory(entry.letterHistory).map((letter) => {
+                                const info = [
+                                  letter.sent_at ? formatDate(letter.sent_at) : null,
+                                  getLetterStatusLabel(letter.status, t)
+                                ]
+                                  .filter(Boolean)
+                                  .join(' • ');
+                                return (
+                                  <li
+                                    key={letter.id}
+                                    className="rounded-lg bg-neutral-50 px-2 py-1 text-[11px] font-medium text-neutral-700 dark:bg-neutral-800/60 dark:text-neutral-200"
+                                  >
+                                    <span>{info}</span>
+                                    {letter.notes && (
+                                      <span className="block text-[11px] font-normal text-neutral-500 dark:text-neutral-400">
+                                        {letter.notes}
+                                      </span>
+                                    )}
+                                  </li>
+                                );
+                              })}
+                            </ul>
+                          </dd>
+                        </div>
+                      )}
+                    </dl>
+                  </article>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default CartasPage;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -4,6 +4,7 @@ export const routePaths: Record<TabKey, string> = {
   territories: '/',
   streets: '/streets',
   buildingsVillages: '/buildings-villages',
+  letters: '/letters',
   exits: '/exits',
   assignments: '/assignments',
   calendar: '/calendar',

--- a/src/services/data-transfer.ts
+++ b/src/services/data-transfer.ts
@@ -3,7 +3,7 @@ import type { Territorio } from '../types/territorio';
 import type { Saida } from '../types/saida';
 import type { Designacao } from '../types/designacao';
 import type { Sugestao } from '../types/sugestao';
-import type { BuildingVillage } from '../types/building_village';
+import { LETTER_STATUS_VALUES, type BuildingVillage } from '../types/building_village';
 import type { Street } from '../types/street';
 import type { PropertyType } from '../types/property-type';
 import type { Address } from '../types/address';
@@ -41,6 +41,15 @@ const sugestaoSchema = z.object({
   dataFinal: z.string()
 });
 
+const letterStatusSchema = z.enum(LETTER_STATUS_VALUES);
+
+const buildingVillageLetterHistorySchema = z.object({
+  id: z.string(),
+  status: letterStatusSchema,
+  sent_at: z.string().nullable().optional().default(null),
+  notes: z.string().nullable().optional().default(null)
+});
+
 const buildingVillageSchema = z.object({
   id: z.string(),
   territory_id: z.string(),
@@ -52,6 +61,12 @@ const buildingVillageSchema = z.object({
   modality: z.string().nullable(),
   reception_type: z.string().nullable(),
   responsible: z.string().nullable(),
+  contact_method: z.string().nullable().optional().default(null),
+  letter_status: letterStatusSchema.nullable().optional().default(null),
+  letter_history: z
+    .array(buildingVillageLetterHistorySchema)
+    .optional()
+    .default([]),
   assigned_at: z.string().nullable(),
   returned_at: z.string().nullable(),
   block: z.string().nullable(),

--- a/src/services/db.test.ts
+++ b/src/services/db.test.ts
@@ -36,6 +36,16 @@ describe('IndexedDB persistence', () => {
         modality: 'vertical',
         reception_type: 'concierge',
         responsible: 'John Doe',
+        contact_method: 'Phone',
+        letter_status: 'sent',
+        letter_history: [
+          {
+            id: 'history-1',
+            status: 'sent',
+            sent_at: '2024-01-02T00:00:00.000Z',
+            notes: 'Initial letter sent'
+          }
+        ],
         assigned_at: '2024-01-01T00:00:00.000Z',
         returned_at: null,
         block: 'A',
@@ -53,6 +63,9 @@ describe('IndexedDB persistence', () => {
         modality: null,
         reception_type: null,
         responsible: null,
+        contact_method: null,
+        letter_status: null,
+        letter_history: [],
         assigned_at: null,
         returned_at: null,
         block: null,
@@ -115,7 +128,17 @@ describe('IndexedDB persistence', () => {
       returned_at: null,
       block: null,
       notes: 'Created during migration test',
-      created_at: '2024-01-02T00:00:00.000Z'
+      created_at: '2024-01-02T00:00:00.000Z',
+      contact_method: 'Email',
+      letter_status: 'in_progress',
+      letter_history: [
+        {
+          id: 'history-migrate-1',
+          status: 'in_progress',
+          sent_at: '2024-01-02T00:00:00.000Z',
+          notes: 'Awaiting confirmation'
+        }
+      ]
     };
 
     await BuildingVillageRepository.add(buildingVillage);

--- a/src/services/repositories/repositories.test.ts
+++ b/src/services/repositories/repositories.test.ts
@@ -312,6 +312,16 @@ describe('BuildingVillageRepository', () => {
       modality: 'vertical',
       reception_type: 'concierge',
       responsible: 'John Doe',
+      contact_method: 'Phone',
+      letter_status: 'sent',
+      letter_history: [
+        {
+          id: 'history-1',
+          status: 'sent',
+          sent_at: '2024-05-02T00:00:00.000Z',
+          notes: 'Initial contact'
+        }
+      ],
       assigned_at: '2024-05-01',
       returned_at: null,
       block: 'A',
@@ -338,6 +348,16 @@ describe('BuildingVillageRepository', () => {
         modality: 'vertical',
         reception_type: 'concierge',
         responsible: 'John Doe',
+        contact_method: 'Phone',
+        letter_status: 'sent',
+        letter_history: [
+          {
+            id: 'history-1',
+            status: 'sent',
+            sent_at: '2024-05-02T00:00:00.000Z',
+            notes: 'Initial contact'
+          }
+        ],
         assigned_at: '2024-05-01',
         returned_at: null,
         block: 'A',
@@ -355,6 +375,9 @@ describe('BuildingVillageRepository', () => {
         modality: null,
         reception_type: null,
         responsible: null,
+        contact_method: null,
+        letter_status: null,
+        letter_history: [],
         assigned_at: null,
         returned_at: null,
         block: null,
@@ -383,6 +406,16 @@ describe('BuildingVillageRepository', () => {
         modality: 'vertical',
         reception_type: 'concierge',
         responsible: 'John Doe',
+        contact_method: 'Phone',
+        letter_status: 'sent',
+        letter_history: [
+          {
+            id: 'history-1',
+            status: 'sent',
+            sent_at: '2024-05-02T00:00:00.000Z',
+            notes: 'Initial contact'
+          }
+        ],
         assigned_at: '2024-05-01',
         returned_at: null,
         block: 'A',
@@ -400,6 +433,9 @@ describe('BuildingVillageRepository', () => {
         modality: null,
         reception_type: null,
         responsible: null,
+        contact_method: null,
+        letter_status: null,
+        letter_history: [],
         assigned_at: null,
         returned_at: null,
         block: null,

--- a/src/types/building_village.ts
+++ b/src/types/building_village.ts
@@ -1,3 +1,14 @@
+export const LETTER_STATUS_VALUES = ['not_sent', 'in_progress', 'sent', 'responded'] as const;
+
+export type BuildingVillageLetterStatus = (typeof LETTER_STATUS_VALUES)[number];
+
+export interface BuildingVillageLetterHistoryEntry {
+  id: string;
+  status: BuildingVillageLetterStatus;
+  sent_at: string | null;
+  notes: string | null;
+}
+
 export interface BuildingVillage {
   id: string;
   territory_id: string;
@@ -9,6 +20,9 @@ export interface BuildingVillage {
   modality: string | null;
   reception_type: string | null;
   responsible: string | null;
+  contact_method: string | null;
+  letter_status: BuildingVillageLetterStatus | null;
+  letter_history: BuildingVillageLetterHistoryEntry[];
   assigned_at: string | null;
   returned_at: string | null;
   block: string | null;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -2,6 +2,7 @@ export type TabKey =
   | 'territories'
   | 'streets'
   | 'buildingsVillages'
+  | 'letters'
   | 'exits'
   | 'assignments'
   | 'calendar'


### PR DESCRIPTION
## Summary
- add contact method and letter tracking fields to the building/village model, repositories, and Dexie migrations
- extend the Predios & Vilas workflow to capture, validate, and display correspondence metadata and history
- introduce a Cartas page plus navigation links to review letters grouped by responsible person and add translations for all locales

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbedbf096c832594e6cc3ef93e2e8d