### PR TITLE
Implement role-based route guards

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { NavLink } from 'react-router-dom';
 import type { TabKey } from '../../types/navigation';
-import { routePaths } from '../../routes';
+import { routePaths, routes } from '../../routes';
+import { useAuth } from '../../hooks/useAuth';
 
 const iconCls = 'w-5 h-5';
 
@@ -86,10 +87,18 @@ const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
 
 export const Sidebar: React.FC = () => {
   const { t } = useTranslation();
+  const { currentUser } = useAuth();
+  const normalizedRole = currentUser?.role?.toLowerCase() ?? null;
+
+  const visibleItems = normalizedRole
+    ? items.filter((it) =>
+        routes[it.id].allowedRoles.some((role) => role.toLowerCase() === normalizedRole),
+      )
+    : [];
 
   return (
     <nav className="bg-white dark:bg-neutral-900 border-r p-2 flex md:flex-col gap-2 md:w-48">
-      {items.map((it) => (
+      {visibleItems.map((it) => (
         <NavLink
           key={it.id}
           to={routePaths[it.id]}

--- a/src/pages/UnauthorizedPage.tsx
+++ b/src/pages/UnauthorizedPage.tsx
@@ -1,0 +1,51 @@
+import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '../hooks/useAuth';
+
+interface UnauthorizedState {
+  from?: string;
+  reason?: 'unauthenticated' | 'unauthorized';
+}
+
+const UnauthorizedPage = () => {
+  const location = useLocation();
+  const { currentUser } = useAuth();
+  const state = (location.state as UnauthorizedState | null) ?? undefined;
+
+  const inferredReason: 'unauthenticated' | 'unauthorized' = state?.reason ?? (currentUser ? 'unauthorized' : 'unauthenticated');
+
+  const messages = {
+    unauthenticated: {
+      title: 'Faça login para continuar',
+      description: 'Entre com uma conta autorizada usando os controles no topo da página.',
+    },
+    unauthorized: {
+      title: 'Acesso não permitido',
+      description: 'Sua conta atual não possui permissão para acessar esta seção.',
+    },
+  } as const;
+
+  return (
+    <section className="flex flex-col items-center justify-center gap-4 py-24 text-center">
+      <div className="max-w-lg space-y-3">
+        <h2 className="text-2xl font-semibold">{messages[inferredReason].title}</h2>
+        <p className="text-neutral-600 dark:text-neutral-300">{messages[inferredReason].description}</p>
+        {state?.from ? (
+          <p className="text-sm text-neutral-500">Rota solicitada: {state.from}</p>
+        ) : null}
+        {currentUser ? (
+          <p className="text-xs uppercase tracking-wide text-neutral-500">
+            Usuário atual: {currentUser.id} · {currentUser.role}
+          </p>
+        ) : null}
+      </div>
+      <Link
+        to="/"
+        className="rounded-xl px-3 py-2 border bg-neutral-100 hover:bg-neutral-200 transition"
+      >
+        Voltar para o início
+      </Link>
+    </section>
+  );
+};
+
+export default UnauthorizedPage;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,18 +1,31 @@
 import type { TabKey } from './types/navigation';
 
-export const routePaths: Record<TabKey, string> = {
-  territories: '/',
-  streets: '/streets',
-  buildingsVillages: '/buildings-villages',
-  letters: '/letters',
-  exits: '/exits',
-  assignments: '/assignments',
-  calendar: '/calendar',
-  suggestions: '/suggestions',
-  notAtHome: '/nao-em-casa'
+export interface RouteDefinition {
+  path: string;
+  allowedRoles: ReadonlyArray<string>;
+}
+
+const managementRoles = ['admin', 'manager'] as const;
+const publisherRoles = [...managementRoles, 'publisher'] as const;
+const readOnlyRoles = [...publisherRoles, 'viewer'] as const;
+
+export const routes: Record<TabKey, RouteDefinition> = {
+  territories: { path: '/', allowedRoles: managementRoles },
+  streets: { path: '/streets', allowedRoles: managementRoles },
+  buildingsVillages: { path: '/buildings-villages', allowedRoles: managementRoles },
+  letters: { path: '/letters', allowedRoles: publisherRoles },
+  exits: { path: '/exits', allowedRoles: managementRoles },
+  assignments: { path: '/assignments', allowedRoles: managementRoles },
+  calendar: { path: '/calendar', allowedRoles: readOnlyRoles },
+  suggestions: { path: '/suggestions', allowedRoles: managementRoles },
+  notAtHome: { path: '/nao-em-casa', allowedRoles: publisherRoles }
 };
 
-export const routeEntries = Object.entries(routePaths) as Array<[
+export const routePaths = Object.fromEntries(
+  Object.entries(routes).map(([key, config]) => [key, config.path])
+) as Record<TabKey, string>;
+
+export const routeEntries = Object.entries(routes) as Array<[
   TabKey,
-  string
+  RouteDefinition
 ]>;


### PR DESCRIPTION
## Summary
- add role metadata to route definitions for every tab
- guard application routes based on the authenticated user role and redirect to an unauthorized screen
- filter sidebar navigation so only links allowed for the current role are visible

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc056368e48325a383dbdbddf2e1a9