### PR TITLE
Scope repositories by publisher

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -90,10 +90,17 @@ const DataManagementControls: React.FC = () => {
   const confirm = useConfirm();
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const { currentUser } = useAuth();
 
   const handleExport = async () => {
     try {
-      await exportData();
+      if (!currentUser?.id) {
+        toast.error(t('app.exportError'));
+        console.error('Exportação falhou: nenhum publicador autenticado.');
+        return;
+      }
+
+      await exportData(currentUser.id);
       toast.success(t('app.exportSuccess'));
     } catch (error) {
       console.error(t('app.exportError'), error);

--- a/src/components/calendar/SchedulerControls.tsx
+++ b/src/components/calendar/SchedulerControls.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import { useMonthlyExportScheduler } from '../../hooks/useMonthlyExportScheduler';
 import { useTranslation } from 'react-i18next';
+import { useMonthlyExportScheduler } from '../../hooks/useMonthlyExportScheduler';
+import { useAuth } from '../../hooks/useAuth';
 
 /**
  * A component for controlling the monthly export scheduler.
@@ -8,7 +9,8 @@ import { useTranslation } from 'react-i18next';
  * @returns A JSX element representing the scheduler controls.
  */
 export const SchedulerControls: React.FC = () => {
-  const { config, setConfig } = useMonthlyExportScheduler();
+  const { currentUser } = useAuth();
+  const { config, setConfig } = useMonthlyExportScheduler(currentUser?.id);
   const { t } = useTranslation();
   const dateValue = new Date(config.nextRun).toISOString().slice(0, 16);
 

--- a/src/hooks/contextHooks.test.ts
+++ b/src/hooks/contextHooks.test.ts
@@ -22,6 +22,7 @@ function createRepositoryMock() {
     remove: vi.fn().mockResolvedValue(undefined),
     clear: vi.fn().mockResolvedValue(undefined),
     all: vi.fn().mockResolvedValue([]),
+    forPublisher: vi.fn().mockResolvedValue([]),
   };
 }
 

--- a/src/hooks/useMonthlyExportScheduler.test.tsx
+++ b/src/hooks/useMonthlyExportScheduler.test.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 
-const designacaoAllMock = vi.fn();
+const designacaoForPublisherMock = vi.fn();
 const exportToCsvMock = vi.fn();
 const downloadFileMock = vi.fn();
 
 vi.mock('../services/repositories/designacoes', () => ({
   DesignacaoRepository: {
-    all: designacaoAllMock,
+    forPublisher: designacaoForPublisherMock,
   },
 }));
 
@@ -77,7 +77,7 @@ describe('useMonthlyExportScheduler', () => {
     const setItemSpy = vi.spyOn(Storage.prototype, 'setItem');
 
     const { useMonthlyExportScheduler } = await import('./useMonthlyExportScheduler');
-    const { result, unmount } = await renderHook(() => useMonthlyExportScheduler());
+    const { result, unmount } = await renderHook(() => useMonthlyExportScheduler('publisher-1'));
 
     try {
       expect(result.current.config).toEqual(storedConfig);
@@ -122,14 +122,14 @@ describe('useMonthlyExportScheduler', () => {
       },
     ];
 
-    designacaoAllMock.mockResolvedValue(designacoes);
+    designacaoForPublisherMock.mockResolvedValue(designacoes);
     exportToCsvMock.mockReturnValue('csv-data');
     downloadFileMock.mockReturnValue(undefined);
 
     vi.setSystemTime(new Date('2024-02-01T00:00:00.000Z'));
 
     const { useMonthlyExportScheduler } = await import('./useMonthlyExportScheduler');
-    const { result, unmount } = await renderHook(() => useMonthlyExportScheduler());
+    const { result, unmount } = await renderHook(() => useMonthlyExportScheduler('publisher-1'));
 
     try {
       expect(result.current.config).toEqual({ enabled: true, nextRun });
@@ -139,7 +139,8 @@ describe('useMonthlyExportScheduler', () => {
       });
       await flushEffects();
 
-      expect(designacaoAllMock).toHaveBeenCalledTimes(1);
+      expect(designacaoForPublisherMock).toHaveBeenCalledWith('publisher-1');
+      expect(designacaoForPublisherMock).toHaveBeenCalledTimes(1);
       expect(exportToCsvMock).toHaveBeenCalledWith(
         [
           {
@@ -174,7 +175,7 @@ describe('useMonthlyExportScheduler', () => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify({ enabled: true, nextRun }));
 
     const { useMonthlyExportScheduler } = await import('./useMonthlyExportScheduler');
-    const { unmount } = await renderHook(() => useMonthlyExportScheduler());
+    const { unmount } = await renderHook(() => useMonthlyExportScheduler('publisher-1'));
 
     try {
       await flushEffects();

--- a/src/services/db.test.ts
+++ b/src/services/db.test.ts
@@ -19,8 +19,15 @@ describe('IndexedDB persistence', () => {
       publisherId: `publisher-${i}`
     }));
     await TerritorioRepository.bulkAdd(territorios);
-    const all = await TerritorioRepository.all();
-    expect(all.length).toBe(territorios.length);
+    const total = await db.territorios.count();
+    expect(total).toBe(territorios.length);
+
+    const sampleIndexes = [0, 500, territorios.length - 1];
+    for (const index of sampleIndexes) {
+      const record = territorios[index];
+      const stored = await TerritorioRepository.forPublisher(record.publisherId);
+      expect(stored).toEqual([record]);
+    }
   });
 
   it('stores and retrieves buildings villages', async () => {
@@ -78,10 +85,15 @@ describe('IndexedDB persistence', () => {
     ];
 
     await BuildingVillageRepository.bulkAdd(buildingVillages);
-    const stored = await BuildingVillageRepository.all();
+    const total = await db.buildingsVillages.count();
+    expect(total).toBe(buildingVillages.length);
 
-    expect(stored).toHaveLength(buildingVillages.length);
-    expect(stored).toEqual(expect.arrayContaining(buildingVillages));
+    await expect(BuildingVillageRepository.forPublisher('publisher-1')).resolves.toEqual([
+      buildingVillages[0]
+    ]);
+    await expect(BuildingVillageRepository.forPublisher('publisher-2')).resolves.toEqual([
+      buildingVillages[1]
+    ]);
   });
 
   it('stores and retrieves not-at-home records', async () => {
@@ -103,7 +115,7 @@ describe('IndexedDB persistence', () => {
     };
 
     await NaoEmCasaRepository.add(record);
-    const stored = await NaoEmCasaRepository.all();
+    const stored = await NaoEmCasaRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([record]);
   });
@@ -147,7 +159,7 @@ describe('IndexedDB persistence', () => {
     };
 
     await BuildingVillageRepository.add(buildingVillage);
-    const stored = await BuildingVillageRepository.all();
+    const stored = await BuildingVillageRepository.forPublisher('publisher-migrate');
     expect(stored).toContainEqual(buildingVillage);
   });
 

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -21,14 +21,14 @@ const formatTimestamp = (date: Date): string => {
   ].join('');
 };
 
-const buildExportPayload = async (): Promise<ExportedData> => {
+const buildExportPayload = async (publisherId: string): Promise<ExportedData> => {
   const [territorios, saidas, designacoes, sugestoes, naoEmCasa, buildingsVillages] = await Promise.all([
-    TerritorioRepository.all(),
-    SaidaRepository.all(),
-    DesignacaoRepository.all(),
-    SugestaoRepository.all(),
-    NaoEmCasaRepository.all(),
-    BuildingVillageRepository.all()
+    TerritorioRepository.forPublisher(publisherId),
+    SaidaRepository.forPublisher(publisherId),
+    DesignacaoRepository.forPublisher(publisherId),
+    SugestaoRepository.forPublisher(publisherId),
+    NaoEmCasaRepository.forPublisher(publisherId),
+    BuildingVillageRepository.forPublisher(publisherId)
   ]);
 
   const [streets, propertyTypes, addresses, derivedTerritories, derivedTerritoryAddresses, metadata] =
@@ -76,8 +76,12 @@ const triggerDownload = (content: string): void => {
 /**
  * Exports all application data to a JSON file that the user can download.
  */
-export const exportData = async (): Promise<void> => {
-  const payload = await buildExportPayload();
+export const exportData = async (publisherId: string): Promise<void> => {
+  if (!publisherId) {
+    throw new Error('Publisher ID is required to export data');
+  }
+
+  const payload = await buildExportPayload(publisherId);
   const content = JSON.stringify(payload, null, 2);
   triggerDownload(content);
 };

--- a/src/services/repositories/buildings_villages.ts
+++ b/src/services/repositories/buildings_villages.ts
@@ -14,6 +14,15 @@ export const BuildingVillageRepository = {
   },
 
   /**
+   * Retrieves all building/village entries that belong to a specific publisher.
+   * @param publisherId The identifier of the publisher whose records should be returned.
+   * @returns A promise that resolves to an array of BuildingVillage objects.
+   */
+  async forPublisher(publisherId: string): Promise<BuildingVillage[]> {
+    return db.buildingsVillages.where('publisherId').equals(publisherId).toArray();
+  },
+
+  /**
    * Adds a new building/village entry to the database.
    * @param buildingVillage The BuildingVillage object to add.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/designacoes.ts
+++ b/src/services/repositories/designacoes.ts
@@ -14,6 +14,15 @@ export const DesignacaoRepository = {
   },
 
   /**
+   * Retrieves the designacoes assigned to a specific publisher.
+   * @param publisherId The identifier of the publisher whose designacoes should be returned.
+   * @returns A promise that resolves to an array of Designacao objects.
+   */
+  async forPublisher(publisherId: string): Promise<Designacao[]> {
+    return db.designacoes.where('publisherId').equals(publisherId).toArray();
+  },
+
+  /**
    * Adds a new designacao to the database.
    * @param designacao The Designacao object to add.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/nao-em-casa.ts
+++ b/src/services/repositories/nao-em-casa.ts
@@ -10,6 +10,15 @@ export const NaoEmCasaRepository = {
     return db.naoEmCasa.toArray();
   },
 
+  /**
+   * Returns the not-at-home records for a specific publisher.
+   * @param publisherId The identifier of the publisher whose records should be returned.
+   * @returns A promise that resolves to an array of not-at-home records.
+   */
+  async forPublisher(publisherId: string): Promise<NaoEmCasaRegistro[]> {
+    return db.naoEmCasa.where('publisherId').equals(publisherId).toArray();
+  },
+
   /** Adds or updates a not-at-home record. */
   async add(registro: NaoEmCasaRegistro): Promise<void> {
     await db.naoEmCasa.put(registro);

--- a/src/services/repositories/repositories.test.ts
+++ b/src/services/repositories/repositories.test.ts
@@ -23,16 +23,16 @@ beforeEach(async () => {
 });
 
 describe('TerritorioRepository', () => {
-  it('adds a territorio and retrieves it with all', async () => {
+  it('adds a territorio and retrieves it with forPublisher', async () => {
     const territorio: Territorio = { id: 'territorio-1', nome: 'Territory 1', publisherId: 'publisher-1' };
 
     await TerritorioRepository.add(territorio);
-    const stored = await TerritorioRepository.all();
+    const stored = await TerritorioRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([territorio]);
   });
 
-  it('bulk adds multiple territorios and retrieves them all', async () => {
+  it('bulk adds multiple territorios and retrieves them per publisher', async () => {
     const territorios: Territorio[] = [
       { id: 'territorio-1', nome: 'Territory 1', publisherId: 'publisher-1' },
       { id: 'territorio-2', nome: 'Territory 2', publisherId: 'publisher-2' },
@@ -40,10 +40,15 @@ describe('TerritorioRepository', () => {
     ];
 
     await TerritorioRepository.bulkAdd(territorios);
-    const stored = await TerritorioRepository.all();
-
-    expect(stored).toHaveLength(territorios.length);
-    expect(stored).toEqual(expect.arrayContaining(territorios));
+    await expect(TerritorioRepository.forPublisher('publisher-1')).resolves.toEqual([
+      territorios[0]
+    ]);
+    await expect(TerritorioRepository.forPublisher('publisher-2')).resolves.toEqual([
+      territorios[1]
+    ]);
+    await expect(TerritorioRepository.forPublisher('publisher-3')).resolves.toEqual([
+      territorios[2]
+    ]);
   });
 
   it('removes a territorio by id', async () => {
@@ -54,10 +59,10 @@ describe('TerritorioRepository', () => {
 
     await TerritorioRepository.bulkAdd(territorios);
     await TerritorioRepository.remove('territorio-1');
-    const stored = await TerritorioRepository.all();
-
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toEqual(territorios[1]);
+    await expect(TerritorioRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(TerritorioRepository.forPublisher('publisher-2')).resolves.toEqual([
+      territorios[1]
+    ]);
   });
 
   it('clears all territorios', async () => {
@@ -68,14 +73,13 @@ describe('TerritorioRepository', () => {
 
     await TerritorioRepository.bulkAdd(territorios);
     await TerritorioRepository.clear();
-    const stored = await TerritorioRepository.all();
-
-    expect(stored).toEqual([]);
+    await expect(TerritorioRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(TerritorioRepository.forPublisher('publisher-2')).resolves.toEqual([]);
   });
 });
 
 describe('SaidaRepository', () => {
-  it('adds a saida and retrieves it with all', async () => {
+  it('adds a saida and retrieves it with forPublisher', async () => {
     const saida: Saida = {
       id: 'saida-1',
       nome: 'Saida 1',
@@ -85,22 +89,20 @@ describe('SaidaRepository', () => {
     };
 
     await SaidaRepository.add(saida);
-    const stored = await SaidaRepository.all();
+    const stored = await SaidaRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([saida]);
   });
 
-  it('bulk adds multiple saidas and retrieves them all', async () => {
+  it('bulk adds multiple saidas and retrieves them per publisher', async () => {
     const saidas: Saida[] = [
       { id: 'saida-1', nome: 'Saida 1', diaDaSemana: 1, hora: '08:00', publisherId: 'publisher-1' },
       { id: 'saida-2', nome: 'Saida 2', diaDaSemana: 2, hora: '09:30', publisherId: 'publisher-2' }
     ];
 
     await SaidaRepository.bulkAdd(saidas);
-    const stored = await SaidaRepository.all();
-
-    expect(stored).toHaveLength(saidas.length);
-    expect(stored).toEqual(expect.arrayContaining(saidas));
+    await expect(SaidaRepository.forPublisher('publisher-1')).resolves.toEqual([saidas[0]]);
+    await expect(SaidaRepository.forPublisher('publisher-2')).resolves.toEqual([saidas[1]]);
   });
 
   it('removes a saida by id', async () => {
@@ -111,15 +113,13 @@ describe('SaidaRepository', () => {
 
     await SaidaRepository.bulkAdd(saidas);
     await SaidaRepository.remove('saida-1');
-    const stored = await SaidaRepository.all();
-
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toEqual(saidas[1]);
+    await expect(SaidaRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(SaidaRepository.forPublisher('publisher-2')).resolves.toEqual([saidas[1]]);
   });
 });
 
 describe('DesignacaoRepository', () => {
-  it('adds a designacao and retrieves it with all', async () => {
+  it('adds a designacao and retrieves it with forPublisher', async () => {
     const designacao: Designacao = {
       id: 'designacao-1',
       territorioId: 'territorio-1',
@@ -130,12 +130,12 @@ describe('DesignacaoRepository', () => {
     };
 
     await DesignacaoRepository.add(designacao);
-    const stored = await DesignacaoRepository.all();
+    const stored = await DesignacaoRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([designacao]);
   });
 
-  it('bulk adds multiple designacoes and retrieves them all', async () => {
+  it('bulk adds multiple designacoes and retrieves them per publisher', async () => {
     const designacoes: Designacao[] = [
       {
         id: 'designacao-1',
@@ -156,10 +156,12 @@ describe('DesignacaoRepository', () => {
     ];
 
     await DesignacaoRepository.bulkAdd(designacoes);
-    const stored = await DesignacaoRepository.all();
-
-    expect(stored).toHaveLength(designacoes.length);
-    expect(stored).toEqual(expect.arrayContaining(designacoes));
+    await expect(DesignacaoRepository.forPublisher('publisher-1')).resolves.toEqual([
+      designacoes[0]
+    ]);
+    await expect(DesignacaoRepository.forPublisher('publisher-2')).resolves.toEqual([
+      designacoes[1]
+    ]);
   });
 
   it('removes a designacao by id', async () => {
@@ -184,15 +186,15 @@ describe('DesignacaoRepository', () => {
 
     await DesignacaoRepository.bulkAdd(designacoes);
     await DesignacaoRepository.remove('designacao-1');
-    const stored = await DesignacaoRepository.all();
-
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toEqual(designacoes[1]);
+    await expect(DesignacaoRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(DesignacaoRepository.forPublisher('publisher-2')).resolves.toEqual([
+      designacoes[1]
+    ]);
   });
 });
 
 describe('SugestaoRepository', () => {
-  it('adds a sugestao and retrieves it with all', async () => {
+  it('adds a sugestao and retrieves it with forPublisher', async () => {
     const sugestao: Sugestao = {
       territorioId: 'territorio-1',
       saidaId: 'saida-1',
@@ -202,12 +204,12 @@ describe('SugestaoRepository', () => {
     };
 
     await SugestaoRepository.add(sugestao);
-    const stored = await SugestaoRepository.all();
+    const stored = await SugestaoRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([sugestao]);
   });
 
-  it('bulk adds multiple sugestoes and retrieves them all', async () => {
+  it('bulk adds multiple sugestoes and retrieves them per publisher', async () => {
     const sugestoes: Sugestao[] = [
       {
         territorioId: 'territorio-1',
@@ -226,10 +228,12 @@ describe('SugestaoRepository', () => {
     ];
 
     await SugestaoRepository.bulkAdd(sugestoes);
-    const stored = await SugestaoRepository.all();
-
-    expect(stored).toHaveLength(sugestoes.length);
-    expect(stored).toEqual(expect.arrayContaining(sugestoes));
+    await expect(SugestaoRepository.forPublisher('publisher-1')).resolves.toEqual([
+      sugestoes[0]
+    ]);
+    await expect(SugestaoRepository.forPublisher('publisher-2')).resolves.toEqual([
+      sugestoes[1]
+    ]);
   });
 
   it('removes a sugestao by composite key', async () => {
@@ -252,15 +256,15 @@ describe('SugestaoRepository', () => {
 
     await SugestaoRepository.bulkAdd(sugestoes);
     await SugestaoRepository.remove('territorio-1', 'saida-1');
-    const stored = await SugestaoRepository.all();
-
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toEqual(sugestoes[1]);
+    await expect(SugestaoRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(SugestaoRepository.forPublisher('publisher-2')).resolves.toEqual([
+      sugestoes[1]
+    ]);
   });
 });
 
 describe('NaoEmCasaRepository', () => {
-  it('adds a record and retrieves it', async () => {
+  it('adds a record and retrieves it with forPublisher', async () => {
     const record: NaoEmCasaRegistro = {
       id: 'record-1',
       territorioId: 'territorio-1',
@@ -278,7 +282,7 @@ describe('NaoEmCasaRepository', () => {
     };
 
     await NaoEmCasaRepository.add(record);
-    const stored = await NaoEmCasaRepository.all();
+    const stored = await NaoEmCasaRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([record]);
   });
@@ -307,14 +311,13 @@ describe('NaoEmCasaRepository', () => {
 
     await NaoEmCasaRepository.bulkAdd(records);
     await NaoEmCasaRepository.remove('record-1');
-    const stored = await NaoEmCasaRepository.all();
-
-    expect(stored).toEqual([records[1]]);
+    await expect(NaoEmCasaRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(NaoEmCasaRepository.forPublisher('publisher-2')).resolves.toEqual([records[1]]);
   });
 });
 
 describe('BuildingVillageRepository', () => {
-  it('adds a building or village and retrieves it with all', async () => {
+  it('adds a building or village and retrieves it with forPublisher', async () => {
     const buildingVillage: BuildingVillage = {
       id: 'bv-1',
       territory_id: 'territory-1',
@@ -345,12 +348,12 @@ describe('BuildingVillageRepository', () => {
     };
 
     await BuildingVillageRepository.add(buildingVillage);
-    const stored = await BuildingVillageRepository.all();
+    const stored = await BuildingVillageRepository.forPublisher('publisher-1');
 
     expect(stored).toEqual([buildingVillage]);
   });
 
-  it('bulk adds multiple buildings or villages and retrieves them all', async () => {
+  it('bulk adds multiple buildings or villages and retrieves them per publisher', async () => {
     const buildingsVillages: BuildingVillage[] = [
       {
         id: 'bv-1',
@@ -404,10 +407,12 @@ describe('BuildingVillageRepository', () => {
     ];
 
     await BuildingVillageRepository.bulkAdd(buildingsVillages);
-    const stored = await BuildingVillageRepository.all();
-
-    expect(stored).toHaveLength(buildingsVillages.length);
-    expect(stored).toEqual(expect.arrayContaining(buildingsVillages));
+    await expect(BuildingVillageRepository.forPublisher('publisher-1')).resolves.toEqual([
+      buildingsVillages[0]
+    ]);
+    await expect(BuildingVillageRepository.forPublisher('publisher-2')).resolves.toEqual([
+      buildingsVillages[1]
+    ]);
   });
 
   it('removes a building or village by id', async () => {
@@ -465,9 +470,9 @@ describe('BuildingVillageRepository', () => {
 
     await BuildingVillageRepository.bulkAdd(buildingsVillages);
     await BuildingVillageRepository.remove('bv-1');
-    const stored = await BuildingVillageRepository.all();
-
-    expect(stored).toHaveLength(1);
-    expect(stored[0]).toEqual(buildingsVillages[1]);
+    await expect(BuildingVillageRepository.forPublisher('publisher-1')).resolves.toEqual([]);
+    await expect(BuildingVillageRepository.forPublisher('publisher-2')).resolves.toEqual([
+      buildingsVillages[1]
+    ]);
   });
 });

--- a/src/services/repositories/saidas.ts
+++ b/src/services/repositories/saidas.ts
@@ -14,6 +14,15 @@ export const SaidaRepository = {
   },
 
   /**
+   * Retrieves all saidas assigned to a specific publisher.
+   * @param publisherId The identifier of the publisher whose saidas should be returned.
+   * @returns A promise that resolves to an array of Saida objects.
+   */
+  async forPublisher(publisherId: string): Promise<Saida[]> {
+    return db.saidas.where('publisherId').equals(publisherId).toArray();
+  },
+
+  /**
    * Adds a new saida to the database.
    * @param saida The Saida object to add.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/sugestoes.ts
+++ b/src/services/repositories/sugestoes.ts
@@ -14,6 +14,15 @@ export const SugestaoRepository = {
   },
 
   /**
+   * Retrieves suggestions belonging to a specific publisher.
+   * @param publisherId The identifier of the publisher whose suggestions should be returned.
+   * @returns A promise that resolves to an array of Sugestao objects.
+   */
+  async forPublisher(publisherId: string): Promise<Sugestao[]> {
+    return db.sugestoes.where('publisherId').equals(publisherId).toArray();
+  },
+
+  /**
    * Adds a new sugestao to the database.
    * @param sugestao The Sugestao object to add.
    * @returns A promise that resolves when the operation is complete.

--- a/src/services/repositories/territorios.ts
+++ b/src/services/repositories/territorios.ts
@@ -14,6 +14,15 @@ export const TerritorioRepository = {
   },
 
   /**
+   * Retrieves territories that belong to a specific publisher.
+   * @param publisherId The identifier of the publisher whose territories should be returned.
+   * @returns A promise that resolves to an array of Territorio objects.
+   */
+  async forPublisher(publisherId: string): Promise<Territorio[]> {
+    return db.territorios.where('publisherId').equals(publisherId).toArray();
+  },
+
+  /**
    * Adds a new territorio to the database.
    * @param territorio The Territorio object to add.
    * @returns A promise that resolves when the operation is complete.


### PR DESCRIPTION
## Summary
- add `forPublisher` helpers across Dexie repositories and adjust tests to assert scoped queries
- load UI screens and background utilities with the authenticated publisher id instead of global fetches
- require the active publisher id for exports and the monthly scheduler so multi-tenant data stays isolated

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc1c90aa9483259ac46f8f620d82cf