### PR TITLE
Add publisher scoping tests and fix RouteGuard

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ interface GuardedRouteProps {
   path: string;
 }
 
-const RouteGuard = ({ component: Component, allowedRoles, currentRole, path }: GuardedRouteProps): JSX.Element => {
+export const RouteGuard = ({ component: Component, allowedRoles, currentRole, path }: GuardedRouteProps): JSX.Element => {
   const normalizedRole = currentRole?.toLowerCase() ?? null;
   const canAccess =
     normalizedRole !== null &&

--- a/src/AppRouteGuard.test.tsx
+++ b/src/AppRouteGuard.test.tsx
@@ -1,0 +1,81 @@
+import type { ComponentType } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import { RouteGuard } from './App';
+import { routes } from './routes';
+
+describe('RouteGuard', () => {
+  const fallbackLabel = 'Acesso negado';
+  const ManagementComponent = () => <div>Gestão</div>;
+  const LettersComponent = () => <div>Cartas</div>;
+
+  afterEach(() => {
+    cleanup();
+    window.history.replaceState({}, '', '/');
+  });
+
+  const renderGuard = ({
+    component,
+    allowedRoles,
+    currentRole,
+    path,
+  }: {
+    component: ComponentType;
+    allowedRoles: ReadonlyArray<string>;
+    currentRole: string | null;
+    path: string;
+  }) => {
+    window.history.replaceState({}, '', path);
+
+    render(
+      <BrowserRouter>
+        <Routes>
+          <Route
+            path={path}
+            element={
+              <RouteGuard
+                component={component}
+                allowedRoles={allowedRoles}
+                currentRole={currentRole}
+                path={path}
+              />
+            }
+          />
+          <Route path="/unauthorized" element={<div>{fallbackLabel}</div>} />
+        </Routes>
+      </BrowserRouter>
+    );
+  };
+
+  it('redirects management-only routes when the user role is not permitted', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: ManagementComponent,
+      allowedRoles: routes.buildingsVillages.allowedRoles,
+      currentRole: 'publisher',
+      path: routes.buildingsVillages.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(fallbackLabel)).toBeDefined();
+    });
+  });
+
+  it('redirects publisher routes when a viewer visits the page', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: LettersComponent,
+      allowedRoles: routes.letters.allowedRoles,
+      currentRole: 'viewer',
+      path: routes.letters.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(fallbackLabel)).toBeDefined();
+    });
+  });
+});

--- a/src/pages/publisherScoping.test.tsx
+++ b/src/pages/publisherScoping.test.tsx
@@ -1,0 +1,224 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeAll, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, waitFor } from '@testing-library/react';
+
+import type { BuildingVillage } from '../types/building_village';
+import type { Territorio } from '../types/territorio';
+import type { AuthUser } from '../store/appReducer';
+
+const {
+  useAuthMock,
+  toastMock,
+  confirmMock,
+  buildingVillageRepositoryMock,
+  territorioRepositoryMock,
+  translationMock,
+} = vi.hoisted(() => {
+  const currentUser: AuthUser = {
+    id: 'publisher-1',
+    role: 'admin',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  };
+
+  const villagesSeed: BuildingVillage[] = [
+    {
+      id: 'bv-1',
+      territory_id: 'territory-1',
+      publisherId: 'publisher-1',
+      name: 'Alpha Tower',
+      address_line: 'Av. Central, 100',
+      type: 'building',
+      number: '100',
+      residences_count: 20,
+      modality: 'vertical',
+      reception_type: 'concierge',
+      responsible: 'Alice',
+      contact_method: 'Email',
+      letter_status: 'sent',
+      letter_history: [
+        { id: 'letter-1', status: 'sent', sent_at: '2024-05-05', notes: 'Delivered' }
+      ],
+      assigned_at: '2024-05-01',
+      returned_at: null,
+      block: 'A',
+      notes: 'Main lobby access',
+      created_at: '2024-05-01',
+    },
+    {
+      id: 'bv-2',
+      territory_id: 'territory-2',
+      publisherId: 'publisher-2',
+      name: 'Beta Plaza',
+      address_line: 'Rua Secundária, 200',
+      type: 'building',
+      number: '200',
+      residences_count: 12,
+      modality: 'vertical',
+      reception_type: 'concierge',
+      responsible: 'Bob',
+      contact_method: 'Phone',
+      letter_status: 'responded',
+      letter_history: [
+        { id: 'letter-2', status: 'responded', sent_at: '2024-04-10', notes: 'Confirmed' }
+      ],
+      assigned_at: '2024-04-01',
+      returned_at: null,
+      block: null,
+      notes: null,
+      created_at: '2024-04-01',
+    },
+    {
+      id: 'bv-3',
+      territory_id: 'territory-1',
+      publisherId: 'publisher-1',
+      name: 'Gamma Court',
+      address_line: 'Praça das Flores, 50',
+      type: 'village',
+      number: '50',
+      residences_count: 8,
+      modality: 'horizontal',
+      reception_type: 'gate',
+      responsible: 'Alice',
+      contact_method: 'Phone',
+      letter_status: 'in_progress',
+      letter_history: [],
+      assigned_at: null,
+      returned_at: null,
+      block: 'B',
+      notes: null,
+      created_at: '2024-05-02',
+    },
+  ];
+
+  const territoriesSeed: Territorio[] = [
+    { id: 'territory-1', nome: 'Norte', publisherId: 'publisher-1' },
+    { id: 'territory-2', nome: 'Sul', publisherId: 'publisher-2' },
+  ];
+
+  const useAuthMock = vi.fn(() => ({
+    currentUser,
+    isAuthenticated: true,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }));
+
+  const toastMock = { success: vi.fn(), error: vi.fn() };
+  const confirmMock = vi.fn(async () => true);
+
+  const cloneVillage = (village: BuildingVillage): BuildingVillage => ({
+    ...village,
+    letter_history: village.letter_history.map((entry) => ({ ...entry })),
+  });
+
+  const buildingVillageRepositoryMock = {
+    forPublisher: vi.fn(async (publisherId: string) =>
+      villagesSeed
+        .filter((village) => village.publisherId === publisherId)
+        .map((village) => cloneVillage(village))
+    ),
+    add: vi.fn(),
+    bulkAdd: vi.fn(),
+    remove: vi.fn(),
+    clear: vi.fn(),
+  };
+
+  const territorioRepositoryMock = {
+    forPublisher: vi.fn(async (publisherId: string) =>
+      territoriesSeed
+        .filter((territory) => territory.publisherId === publisherId)
+        .map((territory) => ({ ...territory }))
+    ),
+  };
+
+  const translationMock = {
+    t: (key: string, options?: Record<string, unknown>) => {
+      if (!options) return key;
+      return `${key} ${Object.values(options).join(' ')}`;
+    },
+  };
+
+  return {
+    useAuthMock,
+    toastMock,
+    confirmMock,
+    buildingVillageRepositoryMock,
+    territorioRepositoryMock,
+    translationMock,
+  };
+});
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../components/feedback/Toast', () => ({
+  useToast: () => toastMock,
+}));
+
+vi.mock('../components/feedback/ConfirmDialog', () => ({
+  useConfirm: () => confirmMock,
+}));
+
+vi.mock('../components/layout/Modal', () => ({
+  Modal: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../services/repositories/buildings_villages', () => ({
+  BuildingVillageRepository: buildingVillageRepositoryMock,
+}));
+
+vi.mock('../services/repositories/territorios', () => ({
+  TerritorioRepository: territorioRepositoryMock,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+let PrediosVilas: (typeof import('./PrediosVilas'))['default'];
+let CartasPage: (typeof import('./CartasPage'))['default'];
+
+beforeAll(async () => {
+  ({ default: PrediosVilas } = await import('./PrediosVilas'));
+  ({ default: CartasPage } = await import('./CartasPage'));
+});
+
+describe('Publisher scoping in pages', () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it('loads only the current publisher records in PrediosVilas', async () => {
+    render(<PrediosVilas />);
+
+    await waitFor(() => {
+      expect(buildingVillageRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
+    });
+
+    await waitFor(() => {
+      const bodyText = document.body.textContent ?? '';
+      expect(bodyText).toMatch(/Alpha Tower/);
+      expect(bodyText).toMatch(/Gamma Court/);
+    });
+
+    expect(document.body.textContent ?? '').not.toMatch(/Beta Plaza/);
+    expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
+  });
+
+  it('groups only the current publisher records in CartasPage', async () => {
+    render(<CartasPage />);
+
+    await waitFor(() => {
+      expect(buildingVillageRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
+    });
+
+    await waitFor(() => {
+      expect(document.body.textContent ?? '').toMatch(/Alice/);
+    });
+
+    expect(document.body.textContent ?? '').not.toMatch(/Bob/);
+    expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
+  });
+});

--- a/src/services/repositories/repositories.test.ts
+++ b/src/services/repositories/repositories.test.ts
@@ -23,6 +23,21 @@ beforeEach(async () => {
 });
 
 describe('TerritorioRepository', () => {
+  it('returns only territorios for the requested publisher', async () => {
+    const territorios: Territorio[] = [
+      { id: 'territorio-1', nome: 'Territory 1', publisherId: 'publisher-1' },
+      { id: 'territorio-2', nome: 'Territory 2', publisherId: 'publisher-2' },
+      { id: 'territorio-3', nome: 'Territory 3', publisherId: 'publisher-1' }
+    ];
+
+    await TerritorioRepository.bulkAdd(territorios);
+
+    await expect(TerritorioRepository.forPublisher('publisher-1')).resolves.toEqual([
+      territorios[0],
+      territorios[2]
+    ]);
+  });
+
   it('adds a territorio and retrieves it with forPublisher', async () => {
     const territorio: Territorio = { id: 'territorio-1', nome: 'Territory 1', publisherId: 'publisher-1' };
 
@@ -79,6 +94,21 @@ describe('TerritorioRepository', () => {
 });
 
 describe('SaidaRepository', () => {
+  it('returns only saidas for the requested publisher', async () => {
+    const saidas: Saida[] = [
+      { id: 'saida-1', nome: 'Saida 1', diaDaSemana: 1, hora: '08:00', publisherId: 'publisher-1' },
+      { id: 'saida-2', nome: 'Saida 2', diaDaSemana: 2, hora: '09:30', publisherId: 'publisher-2' },
+      { id: 'saida-3', nome: 'Saida 3', diaDaSemana: 3, hora: '10:15', publisherId: 'publisher-1' }
+    ];
+
+    await SaidaRepository.bulkAdd(saidas);
+
+    await expect(SaidaRepository.forPublisher('publisher-1')).resolves.toEqual([
+      saidas[0],
+      saidas[2]
+    ]);
+  });
+
   it('adds a saida and retrieves it with forPublisher', async () => {
     const saida: Saida = {
       id: 'saida-1',
@@ -119,6 +149,42 @@ describe('SaidaRepository', () => {
 });
 
 describe('DesignacaoRepository', () => {
+  it('returns only designacoes for the requested publisher', async () => {
+    const designacoes: Designacao[] = [
+      {
+        id: 'designacao-1',
+        territorioId: 'territorio-1',
+        saidaId: 'saida-1',
+        dataInicial: '2024-01-01',
+        dataFinal: '2024-01-31',
+        publisherId: 'publisher-1'
+      },
+      {
+        id: 'designacao-2',
+        territorioId: 'territorio-2',
+        saidaId: 'saida-2',
+        dataInicial: '2024-02-01',
+        dataFinal: '2024-02-29',
+        publisherId: 'publisher-2'
+      },
+      {
+        id: 'designacao-3',
+        territorioId: 'territorio-3',
+        saidaId: 'saida-3',
+        dataInicial: '2024-03-01',
+        dataFinal: '2024-03-31',
+        publisherId: 'publisher-1'
+      }
+    ];
+
+    await DesignacaoRepository.bulkAdd(designacoes);
+
+    await expect(DesignacaoRepository.forPublisher('publisher-1')).resolves.toEqual([
+      designacoes[0],
+      designacoes[2]
+    ]);
+  });
+
   it('adds a designacao and retrieves it with forPublisher', async () => {
     const designacao: Designacao = {
       id: 'designacao-1',
@@ -194,6 +260,39 @@ describe('DesignacaoRepository', () => {
 });
 
 describe('SugestaoRepository', () => {
+  it('returns only sugestoes for the requested publisher', async () => {
+    const sugestoes: Sugestao[] = [
+      {
+        territorioId: 'territorio-1',
+        saidaId: 'saida-1',
+        dataInicial: '2024-03-01',
+        dataFinal: '2024-03-31',
+        publisherId: 'publisher-1'
+      },
+      {
+        territorioId: 'territorio-2',
+        saidaId: 'saida-2',
+        dataInicial: '2024-04-01',
+        dataFinal: '2024-04-30',
+        publisherId: 'publisher-2'
+      },
+      {
+        territorioId: 'territorio-3',
+        saidaId: 'saida-3',
+        dataInicial: '2024-05-01',
+        dataFinal: '2024-05-31',
+        publisherId: 'publisher-1'
+      }
+    ];
+
+    await SugestaoRepository.bulkAdd(sugestoes);
+
+    await expect(SugestaoRepository.forPublisher('publisher-1')).resolves.toEqual([
+      sugestoes[0],
+      sugestoes[2]
+    ]);
+  });
+
   it('adds a sugestao and retrieves it with forPublisher', async () => {
     const sugestao: Sugestao = {
       territorioId: 'territorio-1',
@@ -264,6 +363,45 @@ describe('SugestaoRepository', () => {
 });
 
 describe('NaoEmCasaRepository', () => {
+  it('returns only registros for the requested publisher', async () => {
+    const records: NaoEmCasaRegistro[] = [
+      {
+        id: 'record-1',
+        territorioId: 'territorio-1',
+        publisherId: 'publisher-1',
+        addressId: 1,
+        recordedAt: '2024-01-01',
+        followUpAt: '2024-05-01',
+        completedAt: null
+      },
+      {
+        id: 'record-2',
+        territorioId: 'territorio-2',
+        publisherId: 'publisher-2',
+        addressId: 2,
+        recordedAt: '2024-02-01',
+        followUpAt: '2024-06-01',
+        completedAt: null
+      },
+      {
+        id: 'record-3',
+        territorioId: 'territorio-3',
+        publisherId: 'publisher-1',
+        addressId: 3,
+        recordedAt: '2024-03-01',
+        followUpAt: '2024-07-01',
+        completedAt: null
+      }
+    ];
+
+    await NaoEmCasaRepository.bulkAdd(records);
+
+    await expect(NaoEmCasaRepository.forPublisher('publisher-1')).resolves.toEqual([
+      records[0],
+      records[2]
+    ]);
+  });
+
   it('adds a record and retrieves it with forPublisher', async () => {
     const record: NaoEmCasaRegistro = {
       id: 'record-1',
@@ -317,6 +455,81 @@ describe('NaoEmCasaRepository', () => {
 });
 
 describe('BuildingVillageRepository', () => {
+  it('returns only buildings or villages for the requested publisher', async () => {
+    const buildingsVillages: BuildingVillage[] = [
+      {
+        id: 'bv-1',
+        territory_id: 'territory-1',
+        publisherId: 'publisher-1',
+        name: 'Alpha Tower',
+        address_line: '123 Main St',
+        type: 'building',
+        number: '123',
+        residences_count: 10,
+        modality: 'vertical',
+        reception_type: 'concierge',
+        responsible: 'Alice',
+        contact_method: 'Phone',
+        letter_status: 'sent',
+        letter_history: [],
+        assigned_at: '2024-05-01',
+        returned_at: null,
+        block: 'A',
+        notes: 'Primary entry',
+        created_at: '2024-05-01'
+      },
+      {
+        id: 'bv-2',
+        territory_id: 'territory-2',
+        publisherId: 'publisher-2',
+        name: 'Beta Plaza',
+        address_line: null,
+        type: null,
+        number: null,
+        residences_count: null,
+        modality: null,
+        reception_type: null,
+        responsible: null,
+        contact_method: null,
+        letter_status: null,
+        letter_history: [],
+        assigned_at: null,
+        returned_at: null,
+        block: null,
+        notes: null,
+        created_at: null
+      },
+      {
+        id: 'bv-3',
+        territory_id: 'territory-3',
+        publisherId: 'publisher-1',
+        name: 'Gamma Court',
+        address_line: '456 Side St',
+        type: 'village',
+        number: '456',
+        residences_count: 6,
+        modality: 'horizontal',
+        reception_type: 'intercom',
+        responsible: 'Alice',
+        contact_method: 'Email',
+        letter_status: 'in_progress',
+        letter_history: [],
+        assigned_at: null,
+        returned_at: null,
+        block: null,
+        notes: null,
+        created_at: '2024-05-02'
+      }
+    ];
+
+    await BuildingVillageRepository.bulkAdd(buildingsVillages);
+
+    await expect(BuildingVillageRepository.forPublisher('publisher-1')).resolves.toEqual([
+      buildingsVillages[0],
+      buildingsVillages[2]
+    ]);
+  });
+
   it('adds a building or village and retrieves it with forPublisher', async () => {
     const buildingVillage: BuildingVillage = {
       id: 'bv-1',

--- a/src/store/appReducer.test.ts
+++ b/src/store/appReducer.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from 'vitest';
 import { appReducer, initialState, type AppState, type AuthUser } from './appReducer';
+import {
+  selectCurrentUser,
+  selectDesignacoes,
+  selectNaoEmCasa,
+  selectSaidas,
+  selectSugestoes,
+  selectTerritorios,
+} from './selectors';
 import type { Territorio } from '../types/territorio';
 import type { Saida } from '../types/saida';
 import type { Designacao } from '../types/designacao';
@@ -40,6 +48,43 @@ const baseNaoEmCasa: NaoEmCasaRegistro = {
   addressId: 1,
   recordedAt: '2024-03-01',
   followUpAt: '2024-07-01',
+  completedAt: null,
+};
+
+const otherTerritorio: Territorio = {
+  id: 'territorio-99',
+  nome: 'Outro Território',
+  publisherId: 'publisher-2',
+};
+const otherSaida: Saida = {
+  id: 'saida-99',
+  nome: 'Saída 99',
+  diaDaSemana: 5,
+  hora: '10:00',
+  publisherId: 'publisher-2',
+};
+const otherDesignacao: Designacao = {
+  id: 'designacao-99',
+  territorioId: 'territorio-99',
+  saidaId: 'saida-99',
+  dataInicial: '2024-05-01',
+  dataFinal: '2024-05-07',
+  publisherId: 'publisher-2',
+};
+const otherSugestao: Sugestao = {
+  territorioId: 'territorio-99',
+  saidaId: 'saida-99',
+  dataInicial: '2024-05-08',
+  dataFinal: '2024-05-14',
+  publisherId: 'publisher-2',
+};
+const otherNaoEmCasa: NaoEmCasaRegistro = {
+  id: 'registro-99',
+  territorioId: 'territorio-99',
+  publisherId: 'publisher-2',
+  addressId: 99,
+  recordedAt: '2024-05-01',
+  followUpAt: '2024-09-01',
   completedAt: null,
 };
 
@@ -235,5 +280,42 @@ describe('appReducer', () => {
     const nextState = appReducer(populated, { type: 'RESET_STATE' });
 
     expect(nextState).toEqual(initialState);
+  });
+
+  it('overwrites slices with scoped payloads and exposes them through selectors', () => {
+    const preexisting: AppState = {
+      auth: { currentUser: null },
+      territorios: [otherTerritorio],
+      saidas: [otherSaida],
+      designacoes: [otherDesignacao],
+      sugestoes: [otherSugestao],
+      naoEmCasa: [otherNaoEmCasa],
+    };
+
+    let state = appReducer(preexisting, { type: 'SIGN_IN', payload: baseUser });
+    state = appReducer(state, { type: 'SET_TERRITORIOS', payload: [baseTerritorio] });
+    state = appReducer(state, { type: 'SET_SAIDAS', payload: [baseSaida] });
+    state = appReducer(state, { type: 'SET_DESIGNACOES', payload: [baseDesignacao] });
+    state = appReducer(state, { type: 'SET_SUGESTOES', payload: [baseSugestao] });
+    state = appReducer(state, { type: 'SET_NAO_EM_CASA', payload: [baseNaoEmCasa] });
+
+    expect(state.territorios).toEqual([baseTerritorio]);
+    expect(state.saidas).toEqual([baseSaida]);
+    expect(state.designacoes).toEqual([baseDesignacao]);
+    expect(state.sugestoes).toEqual([baseSugestao]);
+    expect(state.naoEmCasa).toEqual([baseNaoEmCasa]);
+
+    expect(selectCurrentUser(state)).toEqual(baseUser);
+    expect(selectTerritorios(state)).toEqual([baseTerritorio]);
+    expect(selectSaidas(state)).toEqual([baseSaida]);
+    expect(selectDesignacoes(state)).toEqual([baseDesignacao]);
+    expect(selectSugestoes(state)).toEqual([baseSugestao]);
+    expect(selectNaoEmCasa(state)).toEqual([baseNaoEmCasa]);
+
+    expect(preexisting.territorios).toEqual([otherTerritorio]);
+    expect(preexisting.saidas).toEqual([otherSaida]);
+    expect(preexisting.designacoes).toEqual([otherDesignacao]);
+    expect(preexisting.sugestoes).toEqual([otherSugestao]);
+    expect(preexisting.naoEmCasa).toEqual([otherNaoEmCasa]);
   });
 });


### PR DESCRIPTION
## Summary
- export the App RouteGuard and cover unauthorized access redirects with a dedicated test harness
- extend repository and reducer specs to exercise the new publisher-scoped filtering logic across data slices
- add publisher-aware UI tests for PrediosVilas and CartasPage using mocked repositories/auth to ensure only the active publisher's data renders

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc26efb0e883259837d914b436347b