### PR TITLE
Add Link component to custom router

### DIFF
--- a/vendor/react-router-dom/index.d.ts
+++ b/vendor/react-router-dom/index.d.ts
@@ -44,3 +44,9 @@ export interface NavigateProps {
   replace?: boolean;
 }
 export declare function Navigate(props: NavigateProps): null;
+
+export interface LinkProps extends React.AnchorHTMLAttributes<HTMLAnchorElement> {
+  to: string | { pathname?: string };
+  replace?: boolean;
+}
+export declare function Link(props: LinkProps): React.ReactElement;

--- a/vendor/react-router-dom/index.js
+++ b/vendor/react-router-dom/index.js
@@ -118,6 +118,39 @@ export function Route() {
   return null;
 }
 
+function useHref(to) {
+  return typeof to === 'string' ? to : to?.pathname ?? '/';
+}
+
+function isModifiedEvent(event) {
+  return event.metaKey || event.altKey || event.ctrlKey || event.shiftKey;
+}
+
+export function Link({ to, onClick, replace = false, ...rest }) {
+  const { navigate } = React.useContext(RouterContext);
+  const href = useHref(to);
+
+  const handleClick = event => {
+    if (onClick) {
+      onClick(event);
+    }
+
+    if (
+      event.defaultPrevented ||
+      event.button !== 0 ||
+      (rest.target && rest.target !== '_self') ||
+      isModifiedEvent(event)
+    ) {
+      return;
+    }
+
+    event.preventDefault();
+    navigate(href, { replace });
+  };
+
+  return React.createElement('a', { ...rest, href, onClick: handleClick });
+}
+
 export function NavLink({
   to,
   className,
@@ -127,7 +160,7 @@ export function NavLink({
   ...rest
 }) {
   const { location, navigate } = React.useContext(RouterContext);
-  const href = typeof to === 'string' ? to : to?.pathname ?? '/';
+  const href = useHref(to);
   const isActive = end ? matchExact(href, location.pathname) : matchLoose(href, location.pathname);
 
   const classValue =
@@ -148,10 +181,7 @@ export function NavLink({
       event.defaultPrevented ||
       event.button !== 0 ||
       (rest.target && rest.target !== '_self') ||
-      event.metaKey ||
-      event.altKey ||
-      event.ctrlKey ||
-      event.shiftKey
+      isModifiedEvent(event)
     ) {
       return;
     }


### PR DESCRIPTION
## Summary
- add a Link component to the vendored react-router-dom shim so pages can link without errors
- refactor shared href computation and modifier detection used by Link and NavLink
- update type definitions to expose the new Link export

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc41665ca483258bd6f5ead94572bd