### PR TITLE
Add admin master role support for scheduler access

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,8 +33,10 @@ import { BuildingVillageRepository } from './services/repositories/buildings_vil
 import type { TabKey } from './types/navigation';
 import { routeEntries } from './routes';
 import UnauthorizedPage from './pages/UnauthorizedPage';
+import { ADMIN_MASTER_ROLE } from './constants/roles';
 
 const UNAUTHORIZED_ROUTE = '/unauthorized';
+const ADMIN_MASTER_ROLE_NORMALIZED = ADMIN_MASTER_ROLE.toLowerCase();
 
 const pagesByTab: Record<TabKey, ComponentType> = {
   territories: TerritoriesPage,
@@ -186,9 +188,11 @@ const DataManagementControls: React.FC = () => {
   );
 };
 
-const AppContent = () => {
+export const AppContent = () => {
   const { currentUser } = useAuth();
   const currentRole = currentUser?.role ?? null;
+  const normalizedRole = currentRole?.toLowerCase() ?? null;
+  const canManageScheduler = normalizedRole === ADMIN_MASTER_ROLE_NORMALIZED;
 
   return (
     <Shell>
@@ -213,7 +217,7 @@ const AppContent = () => {
         <Route path={UNAUTHORIZED_ROUTE} element={<UnauthorizedPage />} />
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
-      <SchedulerControls />
+      {canManageScheduler && <SchedulerControls />}
       <DataManagementControls />
     </Shell>
   );

--- a/src/AppContent.test.tsx
+++ b/src/AppContent.test.tsx
@@ -1,0 +1,102 @@
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import type { AuthUser } from './store/appReducer';
+import { ADMIN_MASTER_ROLE } from './constants/roles';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockAuthState = {
+  currentUser: null as AuthUser | null,
+  isAuthenticated: false,
+  signIn: vi.fn(),
+  signOut: vi.fn(),
+};
+
+vi.mock('./hooks/useAuth', () => ({
+  useAuth: () => mockAuthState,
+}));
+
+vi.mock('./hooks/useApp', () => ({
+  useApp: () => ({
+    state: {
+      auth: { currentUser: mockAuthState.currentUser },
+      territorios: [],
+      saidas: [],
+      designacoes: [],
+      sugestoes: [],
+      naoEmCasa: [],
+    },
+    dispatch: vi.fn(),
+  }),
+}));
+
+vi.mock('./components/feedback/Toast', () => ({
+  useToast: () => ({ success: vi.fn(), error: vi.fn() }),
+}));
+
+vi.mock('./components/layout/Shell', () => ({
+  Shell: ({ children }: { children: ReactNode }) => (
+    <div data-testid="shell">{children}</div>
+  ),
+}));
+
+vi.mock('./components/calendar/SchedulerControls', () => ({
+  SchedulerControls: () => <div data-testid="scheduler-controls">Scheduler Controls</div>,
+}));
+
+import { AppContent } from './App';
+
+const renderApp = () =>
+  render(
+    <BrowserRouter>
+      <AppContent />
+    </BrowserRouter>,
+  );
+
+describe('AppContent scheduler controls visibility', () => {
+  const baseUser: AuthUser = {
+    id: 'user-1',
+    role: 'publisher',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+
+  beforeEach(() => {
+    mockAuthState.currentUser = null;
+    mockAuthState.isAuthenticated = false;
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders scheduler controls for the admin master role', () => {
+    mockAuthState.currentUser = {
+      ...baseUser,
+      role: ADMIN_MASTER_ROLE.toUpperCase(),
+    };
+    mockAuthState.isAuthenticated = true;
+
+    renderApp();
+
+    expect(screen.getByText('Scheduler Controls')).toBeDefined();
+  });
+
+  it('hides scheduler controls for other roles', () => {
+    mockAuthState.currentUser = {
+      ...baseUser,
+      role: 'manager',
+    };
+    mockAuthState.isAuthenticated = true;
+
+    renderApp();
+
+    expect(screen.queryByText('Scheduler Controls')).toBeNull();
+  });
+});

--- a/src/AppRouteGuard.test.tsx
+++ b/src/AppRouteGuard.test.tsx
@@ -5,6 +5,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 
 import { RouteGuard } from './App';
 import { routes } from './routes';
+import { ADMIN_MASTER_ROLE } from './constants/roles';
 
 describe('RouteGuard', () => {
   const fallbackLabel = 'Acesso negado';
@@ -77,5 +78,21 @@ describe('RouteGuard', () => {
     await waitFor(() => {
       expect(screen.getByText(fallbackLabel)).toBeDefined();
     });
+  });
+
+  it('allows the admin master role to access management routes', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: ManagementComponent,
+      allowedRoles: routes.buildingsVillages.allowedRoles,
+      currentRole: ADMIN_MASTER_ROLE.toUpperCase(),
+      path: routes.buildingsVillages.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Gestão')).toBeDefined();
+    });
+    expect(screen.queryByText(fallbackLabel)).toBeNull();
   });
 });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -4,6 +4,7 @@ import { NavLink } from 'react-router-dom';
 import type { TabKey } from '../../types/navigation';
 import { routePaths, routes } from '../../routes';
 import { useAuth } from '../../hooks/useAuth';
+import { ADMIN_MASTER_ROLE } from '../../constants/roles';
 
 const iconCls = 'w-5 h-5';
 
@@ -85,13 +86,17 @@ const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
   { id: 'suggestions', label: 'sidebar.suggestions', icon: <SuggestIcon /> },
 ];
 
+const ADMIN_MASTER_ROLE_NORMALIZED = ADMIN_MASTER_ROLE.toLowerCase();
+
 export const Sidebar: React.FC = () => {
   const { t } = useTranslation();
   const { currentUser } = useAuth();
   const normalizedRole = currentUser?.role?.toLowerCase() ?? null;
+  const isAdminMaster = normalizedRole === ADMIN_MASTER_ROLE_NORMALIZED;
 
   const visibleItems = normalizedRole
     ? items.filter((it) =>
+        isAdminMaster ||
         routes[it.id].allowedRoles.some((role) => role.toLowerCase() === normalizedRole),
       )
     : [];

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,0 +1,1 @@
+export const ADMIN_MASTER_ROLE = 'admin_master' as const;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -1,11 +1,12 @@
 import type { TabKey } from './types/navigation';
+import { ADMIN_MASTER_ROLE } from './constants/roles';
 
 export interface RouteDefinition {
   path: string;
   allowedRoles: ReadonlyArray<string>;
 }
 
-const managementRoles = ['admin', 'manager'] as const;
+const managementRoles = [ADMIN_MASTER_ROLE, 'admin', 'manager'] as const;
 const publisherRoles = [...managementRoles, 'publisher'] as const;
 const readOnlyRoles = [...publisherRoles, 'viewer'] as const;
 


### PR DESCRIPTION
## Summary
- define a shared ADMIN_MASTER_ROLE constant and include it in all route role groups to preserve full access
- gate SchedulerControls rendering behind the admin master role and allow the sidebar to always display navigation for that role
- cover the new behaviour with unit tests for RouteGuard access and AppContent conditional rendering

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cc5813fdfc83258af5474c7dcc09a0