### PR TITLE
Add property type management UI and seeding

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -192,10 +192,11 @@
     "unnamedBuilding": "Unnamed building/village",
     "unknownTerritory": "Territory unknown"
   },
-    "ruasNumeracoes": {
+  "ruasNumeracoes": {
     "tabs": {
       "streets": "Streets",
       "addresses": "Addresses",
+      "propertyTypes": "Property types",
       "summary": "Summary"
     },
     "territorySelector": {
@@ -229,6 +230,22 @@
       "cooldownTooltip": "Next visit allowed on {{date}}",
       "cooldownAlert": "{{count}} address cannot be revisited until its cooldown expires.",
       "cooldownAlert_plural": "{{count}} addresses cannot be revisited until their cooldowns expire."
+    },
+    "propertyTypesForm": {
+      "namePlaceholder": "Property type name"
+    },
+    "propertyTypesTable": {
+      "name": "Name",
+      "actions": "Actions",
+      "empty": "No property types registered."
+    },
+    "feedback": {
+      "loadError": "Unable to load territories or property types.",
+      "createSuccess": "Property type created successfully.",
+      "updateSuccess": "Property type updated successfully.",
+      "deleteSuccess": "Property type removed successfully.",
+      "saveError": "Unable to save the property type.",
+      "deleteError": "Unable to delete the property type."
     },
     "summary": {
       "totalStreets": "Total streets: {{count}}",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -194,6 +194,7 @@
     "tabs": {
       "streets": "Calles",
       "addresses": "Direcciones",
+      "propertyTypes": "Tipos",
       "summary": "Resumen"
     },
     "territorySelector": {
@@ -227,6 +228,22 @@
       "cooldownTooltip": "Próxima visita permitida el {{date}}",
       "cooldownAlert": "{{count}} dirección está bloqueada hasta que termine el periodo de espera.",
       "cooldownAlert_plural": "{{count}} direcciones están bloqueadas hasta que termine el periodo de espera."
+    },
+    "propertyTypesForm": {
+      "namePlaceholder": "Nombre del tipo de propiedad"
+    },
+    "propertyTypesTable": {
+      "name": "Nombre",
+      "actions": "Acciones",
+      "empty": "Ningún tipo registrado."
+    },
+    "feedback": {
+      "loadError": "No se pudieron cargar los territorios o los tipos de propiedad.",
+      "createSuccess": "Tipo de propiedad creado correctamente.",
+      "updateSuccess": "Tipo de propiedad actualizado correctamente.",
+      "deleteSuccess": "Tipo de propiedad eliminado correctamente.",
+      "saveError": "No se pudo guardar el tipo de propiedad.",
+      "deleteError": "No se pudo eliminar el tipo de propiedad."
     },
     "summary": {
       "totalStreets": "Total de calles: {{count}}",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -197,6 +197,7 @@
     "tabs": {
       "streets": "Ruas",
       "addresses": "Endereços",
+      "propertyTypes": "Tipos",
       "summary": "Resumo"
     },
     "territorySelector": {
@@ -230,6 +231,22 @@
       "cooldownTooltip": "Próxima visita liberada em {{date}}",
       "cooldownAlert": "{{count}} endereço está bloqueado até o fim do período de resfriamento.",
       "cooldownAlert_plural": "{{count}} endereços estão bloqueados até o fim do período de resfriamento."
+    },
+    "propertyTypesForm": {
+      "namePlaceholder": "Nome do tipo de propriedade"
+    },
+    "propertyTypesTable": {
+      "name": "Nome",
+      "actions": "Ações",
+      "empty": "Nenhum tipo cadastrado."
+    },
+    "feedback": {
+      "loadError": "Não foi possível carregar territórios ou tipos de propriedade.",
+      "createSuccess": "Tipo de propriedade criado com sucesso.",
+      "updateSuccess": "Tipo de propriedade atualizado com sucesso.",
+      "deleteSuccess": "Tipo de propriedade removido com sucesso.",
+      "saveError": "Não foi possível salvar o tipo de propriedade.",
+      "deleteError": "Não foi possível remover o tipo de propriedade."
     },
     "summary": {
       "totalStreets": "Total de ruas: {{count}}",

--- a/src/services/db.test.ts
+++ b/src/services/db.test.ts
@@ -1,7 +1,7 @@
 import 'fake-indexeddb/auto';
 import Dexie from 'dexie';
 import { describe, it, expect, beforeEach } from 'vitest';
-import { db, migrate, getSchemaVersion, SCHEMA_VERSION } from './db';
+import { db, migrate, getSchemaVersion, SCHEMA_VERSION, DEFAULT_PROPERTY_TYPE_NAMES } from './db';
 import { TerritorioRepository, BuildingVillageRepository, NaoEmCasaRepository } from './repositories';
 import { ADDRESS_VISIT_COOLDOWN_MS } from '../constants/addresses';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
@@ -161,6 +161,17 @@ describe('IndexedDB persistence', () => {
     await BuildingVillageRepository.add(buildingVillage);
     const stored = await BuildingVillageRepository.forPublisher('publisher-migrate');
     expect(stored).toContainEqual(buildingVillage);
+  });
+
+  it('ensures default property types exist without duplication', async () => {
+    await migrate();
+    await migrate();
+
+    const propertyTypes = await db.propertyTypes.toArray();
+    for (const name of DEFAULT_PROPERTY_TYPE_NAMES) {
+      const matches = propertyTypes.filter((type) => type.name === name);
+      expect(matches).toHaveLength(1);
+    }
   });
 
   it('migrates legacy territorios buildings into the dedicated store', async () => {


### PR DESCRIPTION
## Summary
- seed Dexie with default property types during migrations and cover it with tests
- add property type CRUD controls with toast feedback on RuasNumeracoesPage
- translate the new property type UI strings across supported locales

## Testing
- npm run lint
- npm run test -- src/pages/RuasNumeracoesPage.test.tsx
- npm run test -- src/services/db.test.ts

------
https://chatgpt.com/codex/tasks/task_e_68cc5ae6e0888325b0d33d6fca0f5f0b