### PR TITLE
Add admin-only users management page and persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import AssignmentsPage from './pages/AssignmentsPage';
 import CalendarPage from './pages/CalendarPage';
 import SuggestionsPage from './pages/SuggestionsPage';
 import NaoEmCasaPage from './pages/NaoEmCasaPage';
+import UsersPage from './pages/UsersPage';
 import { AppProvider } from './store/AppProvider';
 import { useApp } from './hooks/useApp';
 import { useAuth } from './hooks/useAuth';
@@ -27,7 +28,8 @@ import {
   SaidaRepository,
   DesignacaoRepository,
   SugestaoRepository,
-  NaoEmCasaRepository
+  NaoEmCasaRepository,
+  UserRepository
 } from './services/repositories';
 import { BuildingVillageRepository } from './services/repositories/buildings_villages';
 import type { TabKey } from './types/navigation';
@@ -45,6 +47,7 @@ const pagesByTab: Record<TabKey, ComponentType> = {
   letters: CartasPage,
   exits: ExitsPage,
   assignments: AssignmentsPage,
+  users: UsersPage,
   calendar: CalendarPage,
   suggestions: SuggestionsPage,
   notAtHome: NaoEmCasaPage,
@@ -125,6 +128,7 @@ const DataManagementControls: React.FC = () => {
       dispatch({ type: 'SET_DESIGNACOES', payload: data.designacoes });
       dispatch({ type: 'SET_SUGESTOES', payload: data.sugestoes });
       dispatch({ type: 'SET_NAO_EM_CASA', payload: data.naoEmCasa });
+      dispatch({ type: 'SET_USERS', payload: data.users });
       toast.success(t('app.importSuccess'));
     } catch (error) {
       console.error(t('app.importError'), error);
@@ -146,6 +150,7 @@ const DataManagementControls: React.FC = () => {
         DesignacaoRepository.clear(),
         SugestaoRepository.clear(),
         NaoEmCasaRepository.clear(),
+        UserRepository.clear(),
         BuildingVillageRepository.clear(),
         db.streets.clear(),
         db.propertyTypes.clear(),

--- a/src/AppRouteGuard.test.tsx
+++ b/src/AppRouteGuard.test.tsx
@@ -11,6 +11,7 @@ describe('RouteGuard', () => {
   const fallbackLabel = 'Acesso negado';
   const ManagementComponent = () => <div>Gestão</div>;
   const LettersComponent = () => <div>Cartas</div>;
+  const UsersComponent = () => <div>Usuários</div>;
 
   afterEach(() => {
     cleanup();
@@ -80,6 +81,21 @@ describe('RouteGuard', () => {
     });
   });
 
+  it('redirects admin users without master privileges from the users route', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: UsersComponent,
+      allowedRoles: routes.users.allowedRoles,
+      currentRole: 'admin',
+      path: routes.users.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(fallbackLabel)).toBeDefined();
+    });
+  });
+
   it('allows the admin master role to access management routes', async () => {
     expect(RouteGuard).toBeDefined();
 
@@ -92,6 +108,22 @@ describe('RouteGuard', () => {
 
     await waitFor(() => {
       expect(screen.getByText('Gestão')).toBeDefined();
+    });
+    expect(screen.queryByText(fallbackLabel)).toBeNull();
+  });
+
+  it('allows the admin master role to access the users route', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: UsersComponent,
+      allowedRoles: routes.users.allowedRoles,
+      currentRole: ADMIN_MASTER_ROLE,
+      path: routes.users.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Usuários')).toBeDefined();
     });
     expect(screen.queryByText(fallbackLabel)).toBeNull();
   });

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -47,6 +47,15 @@ const SuggestIcon = () => (
   </svg>
 );
 
+const UsersIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
+    <path d="M16 21v-2a4 4 0 00-4-4H6a4 4 0 00-4 4v2" />
+    <circle cx="9" cy="7" r="4" />
+    <path d="M22 21v-2a4 4 0 00-3-3.87" />
+    <path d="M16 3.13a4 4 0 010 7.75" />
+  </svg>
+);
+
 const BuildingIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <path d="M3 21h18" />
@@ -81,6 +90,7 @@ const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
   { id: 'letters', label: 'sidebar.letters', icon: <LetterIcon /> },
   { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
   { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
+  { id: 'users', label: 'sidebar.users', icon: <UsersIcon /> },
   { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },
   { id: 'notAtHome', label: 'sidebar.notAtHome', icon: <HomeOffIcon /> },
   { id: 'suggestions', label: 'sidebar.suggestions', icon: <SuggestIcon /> },

--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -1,1 +1,11 @@
 export const ADMIN_MASTER_ROLE = 'admin_master' as const;
+
+export const AVAILABLE_ROLES = [
+  ADMIN_MASTER_ROLE,
+  'admin',
+  'manager',
+  'publisher',
+  'viewer'
+] as const;
+
+export type UserRole = (typeof AVAILABLE_ROLES)[number];

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -1,0 +1,50 @@
+import { useCallback } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useApp } from './useApp';
+import { selectUsers } from '../store/selectors';
+import type { User } from '../types/user';
+import { UserRepository } from '../services/repositories';
+import { useToast } from '../components/feedback/Toast';
+import { generateId } from '../utils/id';
+
+export const useUsers = () => {
+  const { state, dispatch } = useApp();
+  const toast = useToast();
+  const { t } = useTranslation();
+  const users = selectUsers(state);
+
+  return {
+    users,
+    addUser: useCallback(
+      async (user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>) => {
+        const now = new Date().toISOString();
+        const record: User = { id: generateId(), createdAt: now, updatedAt: now, ...user };
+        await UserRepository.add(record);
+        dispatch({ type: 'ADD_USER', payload: record });
+        toast.success(t('users.toast.createSuccess'));
+        return record;
+      },
+      [dispatch, t, toast]
+    ),
+    updateUser: useCallback(
+      async (id: string, user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>) => {
+        const existing = users.find((item) => item.id === id);
+        const createdAt = existing?.createdAt ?? new Date().toISOString();
+        const record: User = { id, createdAt, updatedAt: new Date().toISOString(), ...user };
+        await UserRepository.update(record);
+        dispatch({ type: 'UPDATE_USER', payload: record });
+        toast.success(t('users.toast.updateSuccess'));
+        return record;
+      },
+      [dispatch, t, toast, users]
+    ),
+    removeUser: useCallback(
+      async (id: string) => {
+        await UserRepository.remove(id);
+        dispatch({ type: 'REMOVE_USER', payload: id });
+        toast.success(t('users.toast.deleteSuccess'));
+      },
+      [dispatch, t, toast]
+    ),
+  } as const;
+};

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -274,6 +274,41 @@
     "confirmDelete": "Delete exit?",
     "delete": "Delete"
   },
+  "users": {
+    "pageTitle": "User management",
+    "form": {
+      "createTitle": "New user",
+      "editTitle": "Edit user",
+      "name": "Name",
+      "email": "Email",
+      "role": "Role",
+      "namePlaceholder": "Full name",
+      "emailPlaceholder": "name@example.com",
+      "save": "Save user",
+      "update": "Update user",
+      "cancel": "Cancel edit"
+    },
+    "listTitle": "Registered users ({{count}})",
+    "empty": "No users registered.",
+    "noEmail": "No email provided",
+    "actions": {
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "confirmDelete": "Are you sure you want to remove {{name}}?",
+    "toast": {
+      "createSuccess": "User saved",
+      "updateSuccess": "User updated",
+      "deleteSuccess": "User removed"
+    },
+    "roles": {
+      "admin_master": "Admin master",
+      "admin": "Administrator",
+      "manager": "Manager",
+      "publisher": "Publisher",
+      "viewer": "Viewer"
+    }
+  },
   "territories": {
     "createTerritory": "Create Territory",
     "editTerritory": "Edit Territory",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -272,6 +272,41 @@
     "confirmDelete": "¿Eliminar salida?",
     "delete": "Eliminar"
   },
+  "users": {
+    "pageTitle": "Gestión de usuarios",
+    "form": {
+      "createTitle": "Nuevo usuario",
+      "editTitle": "Editar usuario",
+      "name": "Nombre",
+      "email": "Correo electrónico",
+      "role": "Rol",
+      "namePlaceholder": "Nombre completo",
+      "emailPlaceholder": "nombre@ejemplo.com",
+      "save": "Guardar usuario",
+      "update": "Actualizar usuario",
+      "cancel": "Cancelar edición"
+    },
+    "listTitle": "Usuarios registrados ({{count}})",
+    "empty": "No hay usuarios registrados.",
+    "noEmail": "Sin correo electrónico",
+    "actions": {
+      "edit": "Editar",
+      "delete": "Eliminar"
+    },
+    "confirmDelete": "¿Desea eliminar a {{name}}?",
+    "toast": {
+      "createSuccess": "Usuario guardado",
+      "updateSuccess": "Usuario actualizado",
+      "deleteSuccess": "Usuario eliminado"
+    },
+    "roles": {
+      "admin_master": "Administrador maestro",
+      "admin": "Administrador",
+      "manager": "Gestor",
+      "publisher": "Publicador",
+      "viewer": "Lector"
+    }
+  },
   "territories": {
     "createTerritory": "Registrar territorio",
     "editTerritory": "Editar territorio",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -276,6 +276,41 @@
     "confirmDelete": "Excluir saída?",
     "delete": "Excluir"
   },
+  "users": {
+    "pageTitle": "Gerenciamento de usuários",
+    "form": {
+      "createTitle": "Novo usuário",
+      "editTitle": "Editar usuário",
+      "name": "Nome",
+      "email": "E-mail",
+      "role": "Papel",
+      "namePlaceholder": "Nome completo",
+      "emailPlaceholder": "nome@exemplo.com",
+      "save": "Salvar usuário",
+      "update": "Atualizar usuário",
+      "cancel": "Cancelar edição"
+    },
+    "listTitle": "Usuários cadastrados ({{count}})",
+    "empty": "Nenhum usuário cadastrado.",
+    "noEmail": "Nenhum e-mail informado",
+    "actions": {
+      "edit": "Editar",
+      "delete": "Excluir"
+    },
+    "confirmDelete": "Deseja realmente remover {{name}}?",
+    "toast": {
+      "createSuccess": "Usuário salvo",
+      "updateSuccess": "Usuário atualizado",
+      "deleteSuccess": "Usuário removido"
+    },
+    "roles": {
+      "admin_master": "Admin master",
+      "admin": "Administrador",
+      "manager": "Gerente",
+      "publisher": "Publicador",
+      "viewer": "Leitor"
+    }
+  },
   "territories": {
     "createTerritory": "Cadastrar Território",
     "editTerritory": "Editar Território",

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -1,0 +1,160 @@
+import React, { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useConfirm } from '../components/feedback/ConfirmDialog';
+import { Card, Button, Input, Label } from '../components/ui';
+import { useUsers } from '../hooks/useUsers';
+import type { User } from '../types/user';
+import { AVAILABLE_ROLES, type UserRole } from '../constants/roles';
+
+const DEFAULT_ROLE: UserRole = 'viewer';
+
+const UsersPage: React.FC = () => {
+  const { t } = useTranslation();
+  const confirm = useConfirm();
+  const { users, addUser, updateUser, removeUser } = useUsers();
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [role, setRole] = useState<UserRole>(DEFAULT_ROLE);
+
+  const sortedUsers = useMemo(() => {
+    return [...users].sort((a, b) =>
+      a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })
+    );
+  }, [users]);
+
+  const resetForm = () => {
+    setEditingId(null);
+    setName('');
+    setEmail('');
+    setRole(DEFAULT_ROLE);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const trimmedName = name.trim();
+    const trimmedEmail = email.trim();
+    if (!trimmedName) {
+      return;
+    }
+
+    if (editingId) {
+      await updateUser(editingId, { name: trimmedName, email: trimmedEmail, role });
+    } else {
+      await addUser({ name: trimmedName, email: trimmedEmail, role });
+    }
+
+    resetForm();
+  };
+
+  const handleEdit = (user: User) => {
+    setEditingId(user.id);
+    setName(user.name);
+    setEmail(user.email);
+    setRole(user.role);
+  };
+
+  const handleDelete = async (user: User) => {
+    const shouldDelete = await confirm(t('users.confirmDelete', { name: user.name }));
+    if (!shouldDelete) {
+      return;
+    }
+
+    await removeUser(user.id);
+    if (editingId === user.id) {
+      resetForm();
+    }
+  };
+
+  return (
+    <div className="grid gap-4">
+      <Card title={editingId ? t('users.form.editTitle') : t('users.form.createTitle')}>
+        <form onSubmit={handleSubmit} className="grid gap-3 md:grid-cols-4">
+          <div className="grid gap-1">
+            <Label htmlFor="user-name">{t('users.form.name')}</Label>
+            <Input
+              id="user-name"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              placeholder={t('users.form.namePlaceholder')}
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="user-email">{t('users.form.email')}</Label>
+            <Input
+              id="user-email"
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              placeholder={t('users.form.emailPlaceholder')}
+            />
+          </div>
+          <div className="grid gap-1">
+            <Label htmlFor="user-role">{t('users.form.role')}</Label>
+            <select
+              id="user-role"
+              value={role}
+              onChange={(event) => setRole(event.target.value as UserRole)}
+              className="w-full rounded-xl border px-3 py-2 bg-white dark:bg-neutral-900"
+            >
+              {AVAILABLE_ROLES.map((roleOption) => (
+                <option key={roleOption} value={roleOption}>
+                  {t(`users.roles.${roleOption}`)}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="flex items-end justify-end gap-2">
+            {editingId && (
+              <Button type="button" className="bg-neutral-100" onClick={resetForm}>
+                {t('users.form.cancel')}
+              </Button>
+            )}
+            <Button type="submit" className="bg-black text-white">
+              {editingId ? t('users.form.update') : t('users.form.save')}
+            </Button>
+          </div>
+        </form>
+      </Card>
+
+      <Card title={t('users.listTitle', { count: users.length })}>
+        {sortedUsers.length === 0 ? (
+          <p className="text-neutral-500">{t('users.empty')}</p>
+        ) : (
+          <div className="grid gap-3">
+            {sortedUsers.map((user) => (
+              <div
+                key={user.id}
+                className="rounded-xl border p-3 flex flex-col gap-3 bg-white dark:bg-neutral-900 md:flex-row md:items-center md:justify-between"
+              >
+                <div>
+                  <p className="font-semibold">{user.name}</p>
+                  <p className="text-sm text-neutral-600">
+                    {user.email ? user.email : t('users.noEmail')}
+                  </p>
+                  <p className="text-sm text-neutral-500">{t(`users.roles.${user.role}`)}</p>
+                </div>
+                <div className="flex gap-2">
+                  <Button type="button" className="bg-neutral-100" onClick={() => handleEdit(user)}>
+                    {t('users.actions.edit')}
+                  </Button>
+                  <Button
+                    type="button"
+                    className="bg-red-50 text-red-700"
+                    onClick={() => {
+                      void handleDelete(user);
+                    }}
+                  >
+                    {t('users.actions.delete')}
+                  </Button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+};
+
+export default UsersPage;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -7,6 +7,7 @@ export interface RouteDefinition {
 }
 
 const managementRoles = [ADMIN_MASTER_ROLE, 'admin', 'manager'] as const;
+const adminMasterOnlyRoles = [ADMIN_MASTER_ROLE] as const;
 const publisherRoles = [...managementRoles, 'publisher'] as const;
 const readOnlyRoles = [...publisherRoles, 'viewer'] as const;
 
@@ -17,6 +18,7 @@ export const routes: Record<TabKey, RouteDefinition> = {
   letters: { path: '/letters', allowedRoles: publisherRoles },
   exits: { path: '/exits', allowedRoles: managementRoles },
   assignments: { path: '/assignments', allowedRoles: managementRoles },
+  users: { path: '/users', allowedRoles: adminMasterOnlyRoles },
   calendar: { path: '/calendar', allowedRoles: readOnlyRoles },
   suggestions: { path: '/suggestions', allowedRoles: managementRoles },
   notAtHome: { path: '/nao-em-casa', allowedRoles: publisherRoles }

--- a/src/services/data-transfer.ts
+++ b/src/services/data-transfer.ts
@@ -10,6 +10,8 @@ import type { Address } from '../types/address';
 import type { DerivedTerritory } from '../types/derived-territory';
 import type { Metadata } from './db';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
+import type { User } from '../types/user';
+import { AVAILABLE_ROLES } from '../constants/roles';
 
 const territorioSchema = z.object({
   id: z.string(),
@@ -125,6 +127,15 @@ const derivedTerritoryAddressSchema = z.object({
   addressId: z.number()
 });
 
+const userSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  email: z.string(),
+  role: z.enum(AVAILABLE_ROLES),
+  createdAt: z.string(),
+  updatedAt: z.string()
+});
+
 const metadataSchema = z.object({
   key: z.string(),
   value: z.number()
@@ -145,7 +156,8 @@ export const exportedDataSchema = z
     naoEmCasa: z.array(naoEmCasaSchema).optional().default([]),
     derivedTerritories: z.array(derivedTerritorySchema).optional().default([]),
     derivedTerritoryAddresses: z.array(derivedTerritoryAddressSchema).optional().default([]),
-    metadata: z.array(metadataSchema).optional().default([])
+    metadata: z.array(metadataSchema).optional().default([]),
+    users: z.array(userSchema).optional().default([])
   })
   .transform((data) => ({
     ...data,
@@ -161,7 +173,8 @@ export const exportedDataSchema = z
     naoEmCasa: data.naoEmCasa ?? [],
     derivedTerritories: data.derivedTerritories ?? [],
     derivedTerritoryAddresses: data.derivedTerritoryAddresses ?? [],
-    metadata: data.metadata ?? []
+    metadata: data.metadata ?? [],
+    users: data.users ?? []
   }));
 
 export type ExportedData = {
@@ -179,4 +192,5 @@ export type ExportedData = {
   derivedTerritories: DerivedTerritory[];
   derivedTerritoryAddresses: Array<{ derivedTerritoryId: number; addressId: number }>;
   metadata: Metadata[];
+  users: User[];
 };

--- a/src/services/db.ts
+++ b/src/services/db.ts
@@ -15,6 +15,7 @@ import {
 import type { DerivedTerritory } from '../types/derived-territory';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
 import { ADDRESS_VISIT_COOLDOWN_MS } from '../constants/addresses';
+import type { User } from '../types/user';
 
 export const DEFAULT_PROPERTY_TYPE_NAMES = [
   'Prédio',
@@ -110,6 +111,8 @@ class AppDB extends Dexie {
   metadata!: Table<Metadata, string>;
   /** Table for storing not-at-home records. */
   naoEmCasa!: Table<NaoEmCasaRegistro, string>;
+  /** Table for storing application users. */
+  users!: Table<User, string>;
 
   constructor() {
     super('assigna');
@@ -206,11 +209,41 @@ class AppDB extends Dexie {
           )
         );
       });
+    this.version(8).stores({
+      territorios: 'id, nome, publisherId',
+      saidas: 'id, nome, diaDaSemana, publisherId',
+      designacoes: 'id, territorioId, saidaId, publisherId',
+      sugestoes: '[territorioId+saidaId], territorioId, saidaId, publisherId',
+      metadata: 'key',
+      streets: '++id, territoryId, name',
+      property_types: '++id, name',
+      addresses: '++id, streetId, numberStart, numberEnd, lastSuccessfulVisit, nextVisitAllowed',
+      buildingsVillages: 'id, territory_id, publisherId',
+      derived_territories: '++id, baseTerritoryId, name',
+      derived_territory_addresses: '[derivedTerritoryId+addressId]',
+      nao_em_casa: 'id, territorioId, followUpAt, completedAt, publisherId'
+    });
+    this.version(9).stores({
+      territorios: 'id, nome, publisherId',
+      saidas: 'id, nome, diaDaSemana, publisherId',
+      designacoes: 'id, territorioId, saidaId, publisherId',
+      sugestoes: '[territorioId+saidaId], territorioId, saidaId, publisherId',
+      metadata: 'key',
+      streets: '++id, territoryId, name',
+      property_types: '++id, name',
+      addresses: '++id, streetId, numberStart, numberEnd, lastSuccessfulVisit, nextVisitAllowed',
+      buildingsVillages: 'id, territory_id, publisherId',
+      derived_territories: '++id, baseTerritoryId, name',
+      derived_territory_addresses: '[derivedTerritoryId+addressId]',
+      nao_em_casa: 'id, territorioId, followUpAt, completedAt, publisherId',
+      users: 'id, email, role'
+    });
     this.buildingsVillages = this.table('buildingsVillages');
     this.propertyTypes = this.table('property_types');
     this.derivedTerritories = this.table('derived_territories');
     this.derivedTerritoryAddresses = this.table('derived_territory_addresses');
     this.naoEmCasa = this.table('nao_em_casa');
+    this.users = this.table('users');
   }
 }
 
@@ -221,7 +254,7 @@ export const db = new AppDB();
 /**
  * The current version of the database schema.
  */
-export const SCHEMA_VERSION = 8;
+export const SCHEMA_VERSION = 9;
 
 async function ensureDefaultPropertyTypes(): Promise<void> {
   await db.transaction('rw', db.propertyTypes, async () => {

--- a/src/services/export/index.ts
+++ b/src/services/export/index.ts
@@ -3,7 +3,8 @@ import {
   SaidaRepository,
   SugestaoRepository,
   TerritorioRepository,
-  NaoEmCasaRepository
+  NaoEmCasaRepository,
+  UserRepository
 } from '../repositories';
 import { BuildingVillageRepository } from '../repositories/buildings_villages';
 import { db, SCHEMA_VERSION } from '../db';
@@ -22,14 +23,16 @@ const formatTimestamp = (date: Date): string => {
 };
 
 const buildExportPayload = async (publisherId: string): Promise<ExportedData> => {
-  const [territorios, saidas, designacoes, sugestoes, naoEmCasa, buildingsVillages] = await Promise.all([
-    TerritorioRepository.forPublisher(publisherId),
-    SaidaRepository.forPublisher(publisherId),
-    DesignacaoRepository.forPublisher(publisherId),
-    SugestaoRepository.forPublisher(publisherId),
-    NaoEmCasaRepository.forPublisher(publisherId),
-    BuildingVillageRepository.forPublisher(publisherId)
-  ]);
+  const [territorios, saidas, designacoes, sugestoes, naoEmCasa, buildingsVillages, users] =
+    await Promise.all([
+      TerritorioRepository.forPublisher(publisherId),
+      SaidaRepository.forPublisher(publisherId),
+      DesignacaoRepository.forPublisher(publisherId),
+      SugestaoRepository.forPublisher(publisherId),
+      NaoEmCasaRepository.forPublisher(publisherId),
+      BuildingVillageRepository.forPublisher(publisherId),
+      UserRepository.all()
+    ]);
 
   const [streets, propertyTypes, addresses, derivedTerritories, derivedTerritoryAddresses, metadata] =
     await Promise.all([
@@ -50,6 +53,7 @@ const buildExportPayload = async (publisherId: string): Promise<ExportedData> =>
     sugestoes,
     naoEmCasa,
     buildingsVillages,
+    users,
     streets,
     propertyTypes,
     addresses,

--- a/src/services/import/index.ts
+++ b/src/services/import/index.ts
@@ -5,7 +5,8 @@ import {
   SaidaRepository,
   SugestaoRepository,
   TerritorioRepository,
-  NaoEmCasaRepository
+  NaoEmCasaRepository,
+  UserRepository
 } from '../repositories';
 import { BuildingVillageRepository } from '../repositories/buildings_villages';
 import { db, SCHEMA_VERSION } from '../db';
@@ -61,6 +62,7 @@ export const importData = async (source: ImportSource): Promise<ExportedData> =>
     db.sugestoes,
     db.buildingsVillages,
     db.naoEmCasa,
+    db.users,
     db.streets,
     db.propertyTypes,
     db.addresses,
@@ -75,6 +77,7 @@ export const importData = async (source: ImportSource): Promise<ExportedData> =>
         SugestaoRepository.clear(),
         BuildingVillageRepository.clear(),
         NaoEmCasaRepository.clear(),
+        UserRepository.clear(),
         db.streets.clear(),
         db.propertyTypes.clear(),
         db.addresses.clear(),
@@ -100,6 +103,9 @@ export const importData = async (source: ImportSource): Promise<ExportedData> =>
       }
       if (data.buildingsVillages.length > 0) {
         await BuildingVillageRepository.bulkAdd(data.buildingsVillages);
+      }
+      if (data.users.length > 0) {
+        await UserRepository.bulkAdd(data.users);
       }
       if (data.streets.length > 0) {
         await db.streets.bulkPut(data.streets);

--- a/src/services/repositories/index.ts
+++ b/src/services/repositories/index.ts
@@ -7,3 +7,4 @@ export * from './designacoes';
 export * from './sugestoes';
 export * from './buildings_villages';
 export * from './nao-em-casa';
+export * from './users';

--- a/src/services/repositories/repositories.test.ts
+++ b/src/services/repositories/repositories.test.ts
@@ -8,7 +8,8 @@ import {
   SaidaRepository,
   SugestaoRepository,
   TerritorioRepository,
-  NaoEmCasaRepository
+  NaoEmCasaRepository,
+  UserRepository
 } from '.';
 import type { BuildingVillage } from '../../types/building_village';
 import type { Designacao } from '../../types/designacao';
@@ -16,6 +17,7 @@ import type { Saida } from '../../types/saida';
 import type { Sugestao } from '../../types/sugestao';
 import type { Territorio } from '../../types/territorio';
 import type { NaoEmCasaRegistro } from '../../types/nao-em-casa';
+import type { User } from '../../types/user';
 
 beforeEach(async () => {
   await db.delete();
@@ -687,5 +689,71 @@ describe('BuildingVillageRepository', () => {
     await expect(BuildingVillageRepository.forPublisher('publisher-2')).resolves.toEqual([
       buildingsVillages[1]
     ]);
+  });
+});
+
+describe('UserRepository', () => {
+  it('adds and retrieves all users', async () => {
+    const users: User[] = [
+      {
+        id: 'user-1',
+        name: 'Alice',
+        email: 'alice@example.com',
+        role: 'admin',
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z'
+      },
+      {
+        id: 'user-2',
+        name: 'Bob',
+        email: 'bob@example.com',
+        role: 'publisher',
+        createdAt: '2024-01-02T00:00:00.000Z',
+        updatedAt: '2024-01-02T00:00:00.000Z'
+      }
+    ];
+
+    await UserRepository.bulkAdd(users);
+
+    await expect(UserRepository.all()).resolves.toEqual(users);
+  });
+
+  it('updates an existing user', async () => {
+    const user: User = {
+      id: 'user-3',
+      name: 'Carol',
+      email: 'carol@example.com',
+      role: 'viewer',
+      createdAt: '2024-03-01T00:00:00.000Z',
+      updatedAt: '2024-03-01T00:00:00.000Z'
+    };
+
+    await UserRepository.add(user);
+
+    const updated: User = {
+      ...user,
+      name: 'Caroline',
+      updatedAt: '2024-03-05T00:00:00.000Z'
+    };
+
+    await UserRepository.update(updated);
+
+    await expect(UserRepository.all()).resolves.toEqual([updated]);
+  });
+
+  it('removes a user by id', async () => {
+    const user: User = {
+      id: 'user-4',
+      name: 'Dave',
+      email: 'dave@example.com',
+      role: 'manager',
+      createdAt: '2024-04-01T00:00:00.000Z',
+      updatedAt: '2024-04-01T00:00:00.000Z'
+    };
+
+    await UserRepository.add(user);
+    await UserRepository.remove(user.id);
+
+    await expect(UserRepository.all()).resolves.toEqual([]);
   });
 });

--- a/src/services/repositories/users.ts
+++ b/src/services/repositories/users.ts
@@ -1,0 +1,31 @@
+import type { User } from '../../types/user';
+import { db } from '../db';
+
+export const UserRepository = {
+  async all(): Promise<User[]> {
+    return db.users.toArray();
+  },
+
+  async add(user: User): Promise<void> {
+    await db.users.put(user);
+  },
+
+  async update(user: User): Promise<void> {
+    await db.users.put(user);
+  },
+
+  async bulkAdd(users: User[]): Promise<void> {
+    if (users.length === 0) {
+      return;
+    }
+    await db.users.bulkPut(users);
+  },
+
+  async remove(id: string): Promise<void> {
+    await db.users.delete(id);
+  },
+
+  async clear(): Promise<void> {
+    await db.users.clear();
+  },
+};

--- a/src/store/AppProvider.tsx
+++ b/src/store/AppProvider.tsx
@@ -4,7 +4,8 @@ import {
   SaidaRepository,
   DesignacaoRepository,
   SugestaoRepository,
-  NaoEmCasaRepository
+  NaoEmCasaRepository,
+  UserRepository
 } from '../services/repositories';
 import { appReducer, initialState, AppState, Action } from './appReducer';
 import { loadPersistedAuthState, persistAuthState, clearPersistedAuthState } from './localStore';
@@ -59,16 +60,18 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
             dispatch({ type: 'SET_DESIGNACOES', payload: [] });
             dispatch({ type: 'SET_SUGESTOES', payload: [] });
             dispatch({ type: 'SET_NAO_EM_CASA', payload: [] });
+            dispatch({ type: 'SET_USERS', payload: [] });
           }
           return;
         }
 
-        const [territorios, saidas, designacoes, sugestoes, naoEmCasa] = await Promise.all([
+        const [territorios, saidas, designacoes, sugestoes, naoEmCasa, users] = await Promise.all([
           TerritorioRepository.forPublisher(currentUserId),
           SaidaRepository.forPublisher(currentUserId),
           DesignacaoRepository.forPublisher(currentUserId),
           SugestaoRepository.forPublisher(currentUserId),
-          NaoEmCasaRepository.forPublisher(currentUserId)
+          NaoEmCasaRepository.forPublisher(currentUserId),
+          UserRepository.all()
         ]);
 
         if (!active) return;
@@ -78,6 +81,7 @@ export const AppProvider = ({ children }: { children: ReactNode }) => {
         dispatch({ type: 'SET_DESIGNACOES', payload: designacoes });
         dispatch({ type: 'SET_SUGESTOES', payload: sugestoes });
         dispatch({ type: 'SET_NAO_EM_CASA', payload: naoEmCasa });
+        dispatch({ type: 'SET_USERS', payload: users });
       } catch (error) {
         console.error('Falha ao carregar dados iniciais', error);
       }

--- a/src/store/appReducer.ts
+++ b/src/store/appReducer.ts
@@ -3,6 +3,7 @@ import type { Saida } from '../types/saida';
 import type { Designacao } from '../types/designacao';
 import type { Sugestao } from '../types/sugestao';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
+import type { User } from '../types/user';
 
 export interface AuthUser {
   id: string;
@@ -22,6 +23,7 @@ export interface AppState {
   designacoes: Designacao[];
   sugestoes: Sugestao[];
   naoEmCasa: NaoEmCasaRegistro[];
+  users: User[];
 }
 
 export const initialState: AppState = {
@@ -33,6 +35,7 @@ export const initialState: AppState = {
   designacoes: [],
   sugestoes: [],
   naoEmCasa: [],
+  users: [],
 };
 
 export type Action =
@@ -58,6 +61,10 @@ export type Action =
   | { type: 'ADD_NAO_EM_CASA'; payload: NaoEmCasaRegistro }
   | { type: 'UPDATE_NAO_EM_CASA'; payload: NaoEmCasaRegistro }
   | { type: 'REMOVE_NAO_EM_CASA'; payload: string }
+  | { type: 'SET_USERS'; payload: User[] }
+  | { type: 'ADD_USER'; payload: User }
+  | { type: 'UPDATE_USER'; payload: User }
+  | { type: 'REMOVE_USER'; payload: string }
   | { type: 'RESET_STATE' };
 
 export function appReducer(state: AppState, action: Action): AppState {
@@ -138,6 +145,17 @@ export function appReducer(state: AppState, action: Action): AppState {
       };
     case 'REMOVE_NAO_EM_CASA':
       return { ...state, naoEmCasa: state.naoEmCasa.filter((registro) => registro.id !== action.payload) };
+    case 'SET_USERS':
+      return { ...state, users: [...action.payload] };
+    case 'ADD_USER':
+      return { ...state, users: [...state.users, action.payload] };
+    case 'UPDATE_USER':
+      return {
+        ...state,
+        users: state.users.map((user) => (user.id === action.payload.id ? action.payload : user)),
+      };
+    case 'REMOVE_USER':
+      return { ...state, users: state.users.filter((user) => user.id !== action.payload) };
     case 'RESET_STATE':
       return initialState;
     default:

--- a/src/store/selectors.ts
+++ b/src/store/selectors.ts
@@ -6,3 +6,4 @@ export const selectDesignacoes = (state: AppState) => state.designacoes;
 export const selectSugestoes = (state: AppState) => state.sugestoes;
 export const selectNaoEmCasa = (state: AppState) => state.naoEmCasa;
 export const selectCurrentUser = (state: AppState) => state.auth.currentUser;
+export const selectUsers = (state: AppState) => state.users;

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -5,6 +5,7 @@ export type TabKey =
   | 'letters'
   | 'exits'
   | 'assignments'
+  | 'users'
   | 'calendar'
   | 'suggestions'
   | 'notAtHome';

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,10 @@
+import type { UserRole } from '../constants/roles';
+
+export interface User {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## Summary
- add an admin-only /users route, sidebar tab, and UsersPage component backed by a dedicated hook
- persist managed users through the app state, Dexie repository, and data import/export flows
- expand unit tests to cover the new reducer logic, repository, hook usage, and route guard access rules

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cc61f38d3c832588ac2006e8ca6f65