### PR TITLE
Scope Ruas page data by publisher

### DIFF
--- a/src/pages/RuasNumeracoesPage.test.tsx
+++ b/src/pages/RuasNumeracoesPage.test.tsx
@@ -16,6 +16,8 @@ const {
   defaultAddressesWhere,
   dbMock,
   toastMock,
+  useAuthMock,
+  territorioRepositoryMock,
 } = vi.hoisted(() => {
   const territoriesStore: Territorio[] = [];
   const streetsStore: Street[] = [];
@@ -54,6 +56,15 @@ const {
   });
 
   const toastMock = { success: vi.fn(), error: vi.fn() };
+
+  const useAuthMock = vi.fn();
+  const territorioRepositoryMock = {
+    forPublisher: vi.fn(async (publisherId: string) =>
+      territoriesStore
+        .filter((territory) => territory.publisherId === publisherId)
+        .map((territory) => ({ ...territory }))
+    ),
+  };
 
   const dbMock = {
     territorios: {
@@ -120,11 +131,21 @@ const {
     defaultAddressesWhere,
     dbMock,
     toastMock,
+    useAuthMock,
+    territorioRepositoryMock,
   };
 });
 
 vi.mock('../services/db', () => ({
   db: dbMock,
+}));
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../services/repositories/territorios', () => ({
+  TerritorioRepository: territorioRepositoryMock,
 }));
 
 vi.mock('../components/feedback/Toast', () => ({
@@ -227,8 +248,8 @@ vi.mock('react-i18next', () => ({
 import RuasNumeracoesPage from './RuasNumeracoesPage';
 
 const baseTerritories: Territorio[] = [
-  { id: 'territorio-1', nome: 'Território 1', imageUrl: 'image-1.png' },
-  { id: 'territorio-2', nome: 'Território 2', imageUrl: 'image-2.png' },
+  { id: 'territorio-1', nome: 'Território 1', imageUrl: 'image-1.png', publisherId: 'publisher-1' },
+  { id: 'territorio-2', nome: 'Território 2', imageUrl: 'image-2.png', publisherId: 'publisher-1' },
 ];
 
 const baseStreets: Street[] = [
@@ -254,6 +275,19 @@ const baseAddresses: Address[] = [
 ];
 
 beforeEach(() => {
+  useAuthMock.mockReset();
+  useAuthMock.mockReturnValue({
+    currentUser: {
+      id: 'publisher-1',
+      role: 'admin',
+      createdAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z',
+    },
+    isAuthenticated: true,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  });
+
   territoriesStore.splice(0, territoriesStore.length, ...baseTerritories.map((territory) => ({ ...territory })));
   streetsStore.splice(0, streetsStore.length, ...baseStreets.map((street) => ({ ...street })));
   propertyTypesStore.splice(
@@ -274,6 +308,8 @@ beforeEach(() => {
   dbMock.addresses.where.mockClear();
   dbMock.addresses.put.mockClear();
 
+  territorioRepositoryMock.forPublisher.mockClear();
+
   toastMock.success.mockClear();
   toastMock.error.mockClear();
 
@@ -290,7 +326,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     await waitFor(() => {
@@ -306,7 +342,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     await waitFor(() => {
@@ -339,7 +375,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     const propertyTypesTab = screen.getByRole('button', {
@@ -380,7 +416,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     const propertyTypesTab = screen.getByRole('button', {
@@ -441,7 +477,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     const propertyTypesTab = screen.getByRole('button', {
@@ -486,7 +522,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     const propertyTypesTab = screen.getByRole('button', {
@@ -583,7 +619,7 @@ describe('RuasNumeracoesPage', () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
-      expect(dbMock.territorios.toArray).toHaveBeenCalled();
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
     await waitFor(() => {
@@ -709,7 +745,7 @@ describe('RuasNumeracoesPage', () => {
       render(<RuasNumeracoesPage />);
 
       await waitFor(() => {
-        expect(dbMock.territorios.toArray).toHaveBeenCalled();
+        expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
       });
 
       await waitFor(() => {
@@ -752,7 +788,7 @@ describe('RuasNumeracoesPage', () => {
       render(<RuasNumeracoesPage />);
 
       await waitFor(() => {
-        expect(dbMock.territorios.toArray).toHaveBeenCalled();
+        expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
       });
 
       await waitFor(() => {

--- a/src/pages/streetsPublisherScoping.test.tsx
+++ b/src/pages/streetsPublisherScoping.test.tsx
@@ -1,0 +1,187 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen, waitFor } from '@testing-library/react';
+
+import type { Territorio } from '../types/territorio';
+import type { Street } from '../types/street';
+import type { Address } from '../types/address';
+
+const {
+  useAuthMock,
+  toastMock,
+  territorioRepositoryMock,
+  dbMock,
+  translationMock,
+  requestedStreetTerritories,
+  requestedAddressStreetIds,
+} = vi.hoisted(() => {
+  const currentUser = {
+    id: 'publisher-1',
+    role: 'admin',
+    createdAt: '2024-01-01T00:00:00.000Z',
+    updatedAt: '2024-01-01T00:00:00.000Z',
+  } as const;
+
+  const territoriesSeed: Territorio[] = [
+    { id: 'territory-1', nome: 'Norte', publisherId: currentUser.id, imageUrl: 'norte.png' },
+    { id: 'territory-2', nome: 'Sul', publisherId: 'publisher-2', imageUrl: 'sul.png' },
+  ];
+
+  const streetsSeed: Street[] = [
+    { id: 1, territoryId: 'territory-1', name: 'Rua Norte 1' },
+    { id: 2, territoryId: 'territory-2', name: 'Rua Sul 1' },
+  ];
+
+  const addressesSeed: Address[] = [
+    {
+      id: 100,
+      streetId: 1,
+      numberStart: 1,
+      numberEnd: 10,
+      propertyTypeId: 10,
+      lastSuccessfulVisit: null,
+      nextVisitAllowed: null,
+    },
+    {
+      id: 200,
+      streetId: 2,
+      numberStart: 20,
+      numberEnd: 30,
+      propertyTypeId: 10,
+      lastSuccessfulVisit: null,
+      nextVisitAllowed: null,
+    },
+  ];
+
+  const requestedStreetTerritories: string[] = [];
+  const requestedAddressStreetIds: number[][] = [];
+
+  const useAuthMock = vi.fn(() => ({
+    currentUser,
+    isAuthenticated: true,
+    signIn: vi.fn(),
+    signOut: vi.fn(),
+  }));
+
+  const toastMock = { success: vi.fn(), error: vi.fn() };
+
+  const territorioRepositoryMock = {
+    forPublisher: vi.fn(async (publisherId: string) =>
+      territoriesSeed
+        .filter((territory) => territory.publisherId === publisherId)
+        .map((territory) => ({ ...territory }))
+    ),
+  };
+
+  const dbMock = {
+    propertyTypes: {
+      toArray: vi.fn(async () => [{ id: 10, name: 'Residencial' }]),
+    },
+    streets: {
+      where: vi.fn((field: keyof Street) => ({
+        equals: (value: Street[keyof Street]) => {
+          if (field === 'territoryId' && typeof value === 'string') {
+            requestedStreetTerritories.push(value);
+          }
+          return {
+            async toArray() {
+              return streetsSeed
+                .filter((street) => street[field] === value)
+                .map((street) => ({ ...street }));
+            },
+          };
+        },
+      })),
+      put: vi.fn(),
+    },
+    addresses: {
+      where: vi.fn((field: keyof Address) => ({
+        anyOf: (values: number[]) => {
+          requestedAddressStreetIds.push(values);
+          return {
+            async toArray() {
+              const allowed = new Set(values);
+              return addressesSeed
+                .filter((address) => allowed.has(address[field] as number))
+                .map((address) => ({ ...address }));
+            },
+          };
+        },
+      })),
+      put: vi.fn(),
+    },
+  };
+
+  const translationMock = {
+    t: (key: string) => key,
+  };
+
+  return {
+    useAuthMock,
+    toastMock,
+    territorioRepositoryMock,
+    dbMock,
+    translationMock,
+    requestedStreetTerritories,
+    requestedAddressStreetIds,
+  };
+});
+
+vi.mock('../hooks/useAuth', () => ({
+  useAuth: () => useAuthMock(),
+}));
+
+vi.mock('../services/repositories/territorios', () => ({
+  TerritorioRepository: territorioRepositoryMock,
+}));
+
+vi.mock('../services/db', () => ({
+  db: dbMock,
+}));
+
+vi.mock('../components/feedback/Toast', () => ({
+  useToast: () => toastMock,
+}));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => translationMock,
+}));
+
+vi.mock('../components/ImageAnnotator', () => ({
+  __esModule: true,
+  default: () => <div>Annotator</div>,
+}));
+
+import RuasNumeracoesPage from './RuasNumeracoesPage';
+
+const publisherId = 'publisher-1';
+
+describe('RuasNumeracoesPage publisher scoping', () => {
+  afterEach(() => {
+    cleanup();
+    requestedStreetTerritories.length = 0;
+    requestedAddressStreetIds.length = 0;
+    vi.clearAllMocks();
+  });
+
+  it('loads only the current publisher territories, streets and addresses', async () => {
+    render(<RuasNumeracoesPage />);
+
+    await waitFor(() => {
+      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith(publisherId);
+    });
+
+    const territorySelect = document.getElementById('territory-select') as HTMLSelectElement | null;
+    expect(territorySelect).not.toBeNull();
+    const optionLabels = Array.from(territorySelect!.options).map((option) => option.textContent);
+    expect(optionLabels).toContain('Norte');
+    expect(optionLabels).not.toContain('Sul');
+
+    await waitFor(() => {
+      expect(screen.getByText('Rua Norte 1')).toBeTruthy();
+    });
+    expect(screen.queryByText('Rua Sul 1')).toBeNull();
+
+    expect(requestedStreetTerritories).toEqual(['territory-1']);
+    expect(requestedAddressStreetIds).toEqual([[1]]);
+  });
+});


### PR DESCRIPTION
## Summary
- scope RuasNumeracoesPage data loading and mutations to the current publisher
- clear local state when no authenticated user is present
- add a publisher scoping test covering the ruas page dataset

## Testing
- npm run test -- --run src/pages/RuasNumeracoesPage.test.tsx src/pages/streetsPublisherScoping.test.tsx

------
https://chatgpt.com/codex/tasks/task_e_68cc71d4f1a08325b1c283656ce77307