### PR TITLE
feat: make sidebar responsive to small screens

### DIFF
--- a/src/components/layout/Shell.tsx
+++ b/src/components/layout/Shell.tsx
@@ -15,6 +15,9 @@ export const Shell: React.FC<ShellProps> = ({ children }) => {
     if (stored !== null) return JSON.parse(stored) as boolean;
     return window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
   });
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  const sidebarId = 'app-primary-navigation';
 
   useLayoutEffect(() => {
     document.documentElement.classList.toggle('dark', dark);
@@ -24,12 +27,39 @@ export const Shell: React.FC<ShellProps> = ({ children }) => {
   }, [dark]);
 
   return (
-    <div className="min-h-screen text-neutral-900 dark:text-neutral-100 flex">
-      <Sidebar />
-      <div className="flex-1">
+    <div className="min-h-screen text-neutral-900 dark:text-neutral-100 flex flex-col md:flex-row">
+      <Sidebar id={sidebarId} open={sidebarOpen} onClose={() => setSidebarOpen(false)} />
+      <div className="flex-1 w-full flex flex-col">
         <header className="sticky top-0 z-10 backdrop-blur bg-white/60 dark:bg-neutral-950/50 border-b">
           <div className="max-w-6xl mx-auto px-4 py-3 flex items-center justify-between gap-3">
-            <h1 className="font-bold tracking-tight">Territory Manager</h1>
+            <div className="flex items-center gap-3">
+              <button
+                type="button"
+                className="md:hidden inline-flex items-center justify-center rounded-xl border px-3 py-2"
+                onClick={() => setSidebarOpen((value) => !value)}
+                aria-controls={sidebarId}
+                aria-expanded={sidebarOpen}
+              >
+                <span className="sr-only">
+                  {sidebarOpen
+                    ? t('sidebar.closeMenu', 'Fechar menu de navegação')
+                    : t('sidebar.openMenu', 'Abrir menu de navegação')}
+                </span>
+                <svg
+                  className="h-5 w-5"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  fill="none"
+                  aria-hidden="true"
+                >
+                  <path d="M4 7h16" />
+                  <path d="M4 12h16" />
+                  <path d="M4 17h16" />
+                </svg>
+              </button>
+              <h1 className="font-bold tracking-tight">Territory Manager</h1>
+            </div>
             <div className="flex flex-wrap items-center justify-end gap-2">
               <AuthControls className="flex-shrink-0" />
               <LanguageSelector />
@@ -39,7 +69,7 @@ export const Shell: React.FC<ShellProps> = ({ children }) => {
             </div>
           </div>
         </header>
-        <main className="max-w-6xl mx-auto px-4 py-6 grid gap-4">{children}</main>
+        <main className="max-w-6xl mx-auto px-4 py-6 grid gap-4 flex-1 w-full">{children}</main>
         <footer className="py-8 text-center text-xs text-neutral-500">Dados salvos localmente (localStorage).</footer>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update Shell layout to stack vertically on small viewports and expose a navigation toggle
- add responsive sidebar drawer behaviour with accessibility improvements
- ensure the main content area expands when the sidebar is hidden on smaller screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd46d5590c83259b0cfab26c4ea87f