### PR TITLE
Allow Card header to wrap with responsive alignment

### DIFF
--- a/src/components/ui/Card.tsx
+++ b/src/components/ui/Card.tsx
@@ -7,12 +7,28 @@ export interface CardProps {
   children?: React.ReactNode;
 }
 
-export const Card: React.FC<CardProps> = ({ className = '', title, actions, children }) => (
-  <div className={`rounded-2xl shadow p-4 bg-white/70 dark:bg-neutral-900/60 backdrop-blur border border-black/5 ${className}`}>
-    <div className="flex items-center justify-between mb-3">
-      {title ? <h2 className="text-lg font-semibold">{title}</h2> : <span />}
-      <div className="flex gap-2">{actions}</div>
+export const Card: React.FC<CardProps> = ({ className = '', title, actions, children }) => {
+  const hasTitle = Boolean(title?.trim());
+  const hasActions = actions !== undefined && actions !== null && actions !== false;
+  const showHeader = hasTitle || hasActions;
+
+  return (
+    <div
+      className={`rounded-2xl shadow p-4 bg-white/70 dark:bg-neutral-900/60 backdrop-blur border border-black/5 ${className}`}
+    >
+      {showHeader && (
+        <div className="mb-3 flex flex-col gap-3 sm:flex-row sm:flex-wrap sm:items-center sm:justify-between">
+          {hasTitle && <h2 className="text-lg font-semibold text-neutral-900 dark:text-neutral-100">{title}</h2>}
+          {hasActions && (
+            <div
+              className="flex w-full flex-wrap items-center gap-2 text-neutral-700 dark:text-neutral-200 sm:ml-auto sm:w-auto sm:justify-end"
+            >
+              {actions}
+            </div>
+          )}
+        </div>
+      )}
+      {children}
     </div>
-    {children}
-  </div>
-);
+  );
+};


### PR DESCRIPTION
## Summary
- allow the Card header to stack on small screens while still right-aligning actions when space is available
- render the header only when needed and add color tokens to keep the title/actions legible in light and dark themes

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd4c864cd0832598f71fb7cb7992f2