### PR TITLE
Restrict data management controls to admin masters

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -199,6 +199,7 @@ export const AppContent = () => {
   const currentRole = currentUser?.role ?? null;
   const normalizedRole = currentRole?.toLowerCase() ?? null;
   const canManageScheduler = normalizedRole === ADMIN_MASTER_ROLE_NORMALIZED;
+  const canManageData = normalizedRole === ADMIN_MASTER_ROLE_NORMALIZED;
 
   return (
     <Shell>
@@ -224,7 +225,7 @@ export const AppContent = () => {
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
       {canManageScheduler && <SchedulerControls />}
-      <DataManagementControls />
+      {canManageData && <DataManagementControls />}
     </Shell>
   );
 };


### PR DESCRIPTION
## Summary
- derive a canManageData flag based on the admin master role
- render data management controls only when the current user can manage data

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_e_68cd552bf5988325bb34e254d51c98ac