### PR TITLE
Remove address management from RuasNumeracoesPage

### DIFF
--- a/src/pages/RuasNumeracoesPage.test.tsx
+++ b/src/pages/RuasNumeracoesPage.test.tsx
@@ -1,28 +1,22 @@
 import type { Territorio } from '../types/territorio';
 import type { Street } from '../types/street';
 import type { PropertyType } from '../types/property-type';
-import type { Address } from '../types/address';
-import type { AddressForm } from './RuasNumeracoesPage';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render, screen, waitFor } from '@testing-library/react';
-import { ADDRESS_VISIT_COOLDOWN_MS } from '../constants/addresses';
 
 const {
   territoriesStore,
   streetsStore,
   propertyTypesStore,
-  addressesStore,
   defaultStreetsWhere,
-  defaultAddressesWhere,
   dbMock,
   toastMock,
   useAuthMock,
-  territorioRepositoryMock,
+  territorioRepositoryMock
 } = vi.hoisted(() => {
   const territoriesStore: Territorio[] = [];
   const streetsStore: Street[] = [];
   const propertyTypesStore: PropertyType[] = [];
-  const addressesStore: Address[] = [];
 
   const nextNumericId = (collection: Array<{ id?: number }>): number => {
     const maxId = collection.reduce((max, item) => {
@@ -38,21 +32,10 @@ const {
     equals: (value: Street[keyof Street]) => ({
       async toArray() {
         return streetsStore
-          .filter((street) => street[field] === value)
-          .map((street) => ({ ...street }));
-      },
-    }),
-  });
-
-  const defaultAddressesWhere = (field: keyof Address) => ({
-    anyOf: (values: number[]) => ({
-      async toArray() {
-        const allowed = new Set(values);
-        return addressesStore
-          .filter((address) => allowed.has(address[field] as number))
-          .map((address) => ({ ...address }));
-      },
-    }),
+          .filter(street => street[field] === value)
+          .map(street => ({ ...street }));
+      }
+    })
   });
 
   const toastMock = { success: vi.fn(), error: vi.fn() };
@@ -61,36 +44,36 @@ const {
   const territorioRepositoryMock = {
     forPublisher: vi.fn(async (publisherId: string) =>
       territoriesStore
-        .filter((territory) => territory.publisherId === publisherId)
-        .map((territory) => ({ ...territory }))
-    ),
+        .filter(territory => territory.publisherId === publisherId)
+        .map(territory => ({ ...territory }))
+    )
   };
 
   const dbMock = {
     territorios: {
-      toArray: vi.fn(async () => territoriesStore.map((territory) => ({ ...territory }))),
+      toArray: vi.fn(async () => territoriesStore.map(territory => ({ ...territory })))
     },
     streets: {
-      toArray: vi.fn(async () => streetsStore.map((street) => ({ ...street }))),
+      toArray: vi.fn(async () => streetsStore.map(street => ({ ...street }))),
       where: vi.fn(defaultStreetsWhere),
       put: vi.fn(async (street: Street) => {
         const id = typeof street.id === 'number' ? street.id : nextNumericId(streetsStore);
         const record: Street = { id, ...street };
-        const index = streetsStore.findIndex((item) => item.id === id);
+        const index = streetsStore.findIndex(item => item.id === id);
         if (index >= 0) {
           streetsStore[index] = record;
         } else {
           streetsStore.push(record);
         }
         return id;
-      }),
+      })
     },
     propertyTypes: {
-      toArray: vi.fn(async () => propertyTypesStore.map((type) => ({ ...type }))),
+      toArray: vi.fn(async () => propertyTypesStore.map(type => ({ ...type }))),
       put: vi.fn(async (type: PropertyType) => {
         const id = typeof type.id === 'number' ? type.id : nextNumericId(propertyTypesStore);
         const record: PropertyType = { id, ...type };
-        const index = propertyTypesStore.findIndex((item) => item.id === id);
+        const index = propertyTypesStore.findIndex(item => item.id === id);
         if (index >= 0) {
           propertyTypesStore[index] = record;
         } else {
@@ -99,125 +82,78 @@ const {
         return id;
       }),
       delete: vi.fn(async (id: number) => {
-        const index = propertyTypesStore.findIndex((item) => item.id === id);
+        const index = propertyTypesStore.findIndex(item => item.id === id);
         if (index >= 0) {
           propertyTypesStore.splice(index, 1);
         }
-      }),
-    },
-    addresses: {
-      toArray: vi.fn(async () => addressesStore.map((address) => ({ ...address }))),
-      where: vi.fn(defaultAddressesWhere),
-      put: vi.fn(async (address: Address) => {
-        const id = typeof address.id === 'number' ? address.id : nextNumericId(addressesStore);
-        const record: Address = { id, ...address };
-        const index = addressesStore.findIndex((item) => item.id === id);
-        if (index >= 0) {
-          addressesStore[index] = record;
-        } else {
-          addressesStore.push(record);
-        }
-        return id;
-      }),
-    },
+      })
+    }
   };
 
   return {
     territoriesStore,
     streetsStore,
     propertyTypesStore,
-    addressesStore,
     defaultStreetsWhere,
-    defaultAddressesWhere,
     dbMock,
     toastMock,
     useAuthMock,
-    territorioRepositoryMock,
+    territorioRepositoryMock
   };
 });
 
 vi.mock('../services/db', () => ({
-  db: dbMock,
+  db: dbMock
 }));
 
 vi.mock('../hooks/useAuth', () => ({
-  useAuth: () => useAuthMock(),
+  useAuth: () => useAuthMock()
 }));
 
 vi.mock('../services/repositories/territorios', () => ({
-  TerritorioRepository: territorioRepositoryMock,
+  TerritorioRepository: territorioRepositoryMock
 }));
 
 vi.mock('../components/feedback/Toast', () => ({
-  useToast: () => toastMock,
+  useToast: () => toastMock
 }));
 
 vi.mock('../components/ImageAnnotator', () => ({
   __esModule: true,
-  default: ({
-    onAdd,
-    onUpdate,
-    onDelete,
-  }: {
-    onAdd?: () => void;
-    onUpdate?: () => void;
-    onDelete?: () => void;
-  }) => (
-    <div>
-      <button type="button" data-testid="annotator-add" onClick={() => onAdd?.()}>
-        Annotator Add
-      </button>
-      <button type="button" data-testid="annotator-update" onClick={() => onUpdate?.()}>
-        Annotator Update
-      </button>
-      <button type="button" data-testid="annotator-delete" onClick={() => onDelete?.()}>
-        Annotator Delete
-      </button>
-    </div>
-  ),
+  default: ({ imageUrl }: { imageUrl: string }) => (
+    <div data-testid="image-annotator">{imageUrl}</div>
+  )
 }));
 
-vi.mock('react-hook-form', () => ({
-  useForm: () => {
-    const values: Partial<AddressForm> = {};
-
-    const register = (name: keyof AddressForm) => {
-      const handler = (event: Event) => {
-        const target = event.target as HTMLInputElement | HTMLSelectElement;
-        values[name] = target.value as never;
-      };
-
-      return {
-        name,
-        onChange: handler,
-        onInput: handler,
-      };
-    };
-
-    const toNumber = (value: unknown): number => {
-      return value === undefined || value === '' ? NaN : Number(value);
-    };
-
-    const handleSubmit = (callback: (data: AddressForm) => unknown) => async (event?: Event) => {
-      event?.preventDefault();
-      await callback({
-        streetId: toNumber(values.streetId),
-        propertyTypeId: toNumber(values.propertyTypeId),
-        numberStart: toNumber(values.numberStart),
-        numberEnd: toNumber(values.numberEnd),
-        id: values.id === undefined ? undefined : toNumber(values.id),
-      });
-    };
-
-    const reset = () => {
-      Object.keys(values).forEach((key) => {
-        values[key as keyof AddressForm] = undefined as never;
-      });
-    };
-
-    return { register, handleSubmit, reset };
-  },
+const translationMock = vi.hoisted(() => ({
+  t: (key: string, options?: Record<string, unknown>) => {
+    if (options?.count !== undefined) {
+      return `${key} (${options.count})`;
+    }
+    return key;
+  }
 }));
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => translationMock
+}));
+
+import RuasNumeracoesPage from './RuasNumeracoesPage';
+
+const baseTerritories: Territorio[] = [
+  { id: 'territorio-1', nome: 'Território 1', imageUrl: 'image-1.png', publisherId: 'publisher-1' },
+  { id: 'territorio-2', nome: 'Território 2', imageUrl: 'image-2.png', publisherId: 'publisher-1' }
+];
+
+const baseStreets: Street[] = [
+  { id: 1, territoryId: 'territorio-1', name: 'Rua Principal' },
+  { id: 2, territoryId: 'territorio-2', name: 'Avenida Secundária' }
+];
+
+const basePropertyTypes: PropertyType[] = [
+  { id: 10, name: 'Casa' },
+  { id: 20, name: 'Apartamento' }
+];
 
 const setInputValue = (input: HTMLInputElement, value: string): void => {
   const prototype = Object.getPrototypeOf(input) as HTMLInputElement;
@@ -232,48 +168,6 @@ const setInputValue = (input: HTMLInputElement, value: string): void => {
   input.dispatchEvent(new Event('change', { bubbles: true }));
 };
 
-const translationMock = vi.hoisted(() => ({
-  t: (key: string, options?: Record<string, unknown>) => {
-    if (options?.count !== undefined) {
-      return `${key} (${options.count})`;
-    }
-    return key;
-  },
-}));
-
-vi.mock('react-i18next', () => ({
-  useTranslation: () => translationMock,
-}));
-
-import RuasNumeracoesPage from './RuasNumeracoesPage';
-
-const baseTerritories: Territorio[] = [
-  { id: 'territorio-1', nome: 'Território 1', imageUrl: 'image-1.png', publisherId: 'publisher-1' },
-  { id: 'territorio-2', nome: 'Território 2', imageUrl: 'image-2.png', publisherId: 'publisher-1' },
-];
-
-const baseStreets: Street[] = [
-  { id: 1, territoryId: 'territorio-1', name: 'Rua Principal' },
-  { id: 2, territoryId: 'territorio-2', name: 'Avenida Secundária' },
-];
-
-const basePropertyTypes: PropertyType[] = [
-  { id: 10, name: 'Casa' },
-  { id: 20, name: 'Apartamento' },
-];
-
-const baseAddresses: Address[] = [
-  {
-    id: 5,
-    streetId: 1,
-    numberStart: 1,
-    numberEnd: 10,
-    propertyTypeId: 10,
-    lastSuccessfulVisit: null,
-    nextVisitAllowed: null,
-  },
-];
-
 beforeEach(() => {
   useAuthMock.mockReset();
   useAuthMock.mockReturnValue({
@@ -281,21 +175,16 @@ beforeEach(() => {
       id: 'publisher-1',
       role: 'admin',
       createdAt: '2024-01-01T00:00:00.000Z',
-      updatedAt: '2024-01-01T00:00:00.000Z',
+      updatedAt: '2024-01-01T00:00:00.000Z'
     },
     isAuthenticated: true,
     signIn: vi.fn(),
-    signOut: vi.fn(),
+    signOut: vi.fn()
   });
 
-  territoriesStore.splice(0, territoriesStore.length, ...baseTerritories.map((territory) => ({ ...territory })));
-  streetsStore.splice(0, streetsStore.length, ...baseStreets.map((street) => ({ ...street })));
-  propertyTypesStore.splice(
-    0,
-    propertyTypesStore.length,
-    ...basePropertyTypes.map((type) => ({ ...type })),
-  );
-  addressesStore.splice(0, addressesStore.length, ...baseAddresses.map((address) => ({ ...address })));
+  territoriesStore.splice(0, territoriesStore.length, ...baseTerritories.map(territory => ({ ...territory })));
+  streetsStore.splice(0, streetsStore.length, ...baseStreets.map(street => ({ ...street })));
+  propertyTypesStore.splice(0, propertyTypesStore.length, ...basePropertyTypes.map(type => ({ ...type })));
 
   dbMock.territorios.toArray.mockClear();
   dbMock.streets.toArray.mockClear();
@@ -304,9 +193,6 @@ beforeEach(() => {
   dbMock.propertyTypes.toArray.mockClear();
   dbMock.propertyTypes.put.mockClear();
   dbMock.propertyTypes.delete.mockClear();
-  dbMock.addresses.toArray.mockClear();
-  dbMock.addresses.where.mockClear();
-  dbMock.addresses.put.mockClear();
 
   territorioRepositoryMock.forPublisher.mockClear();
 
@@ -314,7 +200,6 @@ beforeEach(() => {
   toastMock.error.mockClear();
 
   dbMock.streets.where.mockImplementation(defaultStreetsWhere);
-  dbMock.addresses.where.mockImplementation(defaultAddressesWhere);
 });
 
 afterEach(() => {
@@ -350,7 +235,7 @@ describe('RuasNumeracoesPage', () => {
     });
 
     const input = screen.getByPlaceholderText(
-      'ruasNumeracoes.streetsForm.streetNamePlaceholder',
+      'ruasNumeracoes.streetsForm.streetNamePlaceholder'
     ) as HTMLInputElement;
     input.value = 'Nova Rua';
 
@@ -367,7 +252,7 @@ describe('RuasNumeracoesPage', () => {
 
     expect(dbMock.streets.put).toHaveBeenCalledWith({
       territoryId: 'territorio-1',
-      name: 'Nova Rua',
+      name: 'Nova Rua'
     });
   });
 
@@ -379,7 +264,7 @@ describe('RuasNumeracoesPage', () => {
     });
 
     const propertyTypesTab = screen.getByRole('button', {
-      name: 'ruasNumeracoes.tabs.propertyTypes',
+      name: 'ruasNumeracoes.tabs.propertyTypes'
     });
 
     await act(async () => {
@@ -387,7 +272,7 @@ describe('RuasNumeracoesPage', () => {
     });
 
     const input = screen.getByPlaceholderText(
-      'ruasNumeracoes.propertyTypesForm.namePlaceholder',
+      'ruasNumeracoes.propertyTypesForm.namePlaceholder'
     ) as HTMLInputElement;
     input.value = 'Residencial Nova';
 
@@ -420,7 +305,7 @@ describe('RuasNumeracoesPage', () => {
     });
 
     const propertyTypesTab = screen.getByRole('button', {
-      name: 'ruasNumeracoes.tabs.propertyTypes',
+      name: 'ruasNumeracoes.tabs.propertyTypes'
     });
 
     await act(async () => {
@@ -436,7 +321,7 @@ describe('RuasNumeracoesPage', () => {
 
     const editButton = screen
       .getAllByRole('button', { name: 'common.edit' })
-      .find((button) => button.closest('tr') === targetRow);
+      .find(button => button.closest('tr') === targetRow);
     expect(editButton).toBeDefined();
 
     await act(async () => {
@@ -452,7 +337,7 @@ describe('RuasNumeracoesPage', () => {
 
     const saveButton = screen
       .getAllByRole('button', { name: 'common.save' })
-      .find((button) => button.closest('tr') === targetRow);
+      .find(button => button.closest('tr') === targetRow);
     expect(saveButton).toBeDefined();
 
     await act(async () => {
@@ -481,7 +366,7 @@ describe('RuasNumeracoesPage', () => {
     });
 
     const propertyTypesTab = screen.getByRole('button', {
-      name: 'ruasNumeracoes.tabs.propertyTypes',
+      name: 'ruasNumeracoes.tabs.propertyTypes'
     });
 
     await act(async () => {
@@ -497,7 +382,7 @@ describe('RuasNumeracoesPage', () => {
 
     const deleteButton = screen
       .getAllByRole('button', { name: 'common.delete' })
-      .find((button) => button.closest('tr') === targetRow);
+      .find(button => button.closest('tr') === targetRow);
     expect(deleteButton).toBeDefined();
 
     await act(async () => {
@@ -518,330 +403,23 @@ describe('RuasNumeracoesPage', () => {
     });
   });
 
-  it('uses a newly created property type when saving an address', async () => {
+  it('displays a summary with street and property type counts', async () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
       expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
     });
 
-    const propertyTypesTab = screen.getByRole('button', {
-      name: 'ruasNumeracoes.tabs.propertyTypes',
+    const summaryTab = screen.getByRole('button', {
+      name: 'ruasNumeracoes.tabs.summary'
     });
 
     await act(async () => {
-      propertyTypesTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      summaryTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    const input = screen.getByPlaceholderText(
-      'ruasNumeracoes.propertyTypesForm.namePlaceholder',
-    ) as HTMLInputElement;
-    input.value = 'Comercial';
-
-    const form = input.closest('form');
-    expect(form).toBeTruthy();
-
-    await act(async () => {
-      form?.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));
-      await Promise.resolve();
-    });
-
-    await waitFor(() => {
-      expect(dbMock.propertyTypes.put).toHaveBeenCalledWith({ name: 'Comercial' });
-    });
-
-    const createdType = propertyTypesStore.find((type) => type.name === 'Comercial');
-    expect(createdType).toBeDefined();
-
-    const addressesTab = screen.getByRole('button', {
-      name: 'ruasNumeracoes.tabs.addresses',
-    });
-
-    await act(async () => {
-      addressesTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-
-    const streetSelect = document.querySelector('select[name="streetId"]') as HTMLSelectElement | null;
-    const propertyTypeSelect = document.querySelector('select[name="propertyTypeId"]') as HTMLSelectElement | null;
-
-    expect(streetSelect).not.toBeNull();
-    expect(propertyTypeSelect).not.toBeNull();
-
-    await act(async () => {
-      streetSelect!.value = '1';
-      streetSelect!.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    await act(async () => {
-      propertyTypeSelect!.value = String(createdType!.id);
-      propertyTypeSelect!.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    const numberStartInput = screen.getByPlaceholderText(
-      'ruasNumeracoes.addressesForm.numberStart',
-    ) as HTMLInputElement;
-    const numberEndInput = screen.getByPlaceholderText(
-      'ruasNumeracoes.addressesForm.numberEnd',
-    ) as HTMLInputElement;
-
-    await act(async () => {
-      numberStartInput.value = '300';
-      numberStartInput.dispatchEvent(new Event('input', { bubbles: true }));
-      numberStartInput.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    await act(async () => {
-      numberEndInput.value = '400';
-      numberEndInput.dispatchEvent(new Event('input', { bubbles: true }));
-      numberEndInput.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    const saveButton = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement;
-
-    await act(async () => {
-      saveButton.click();
-      await Promise.resolve();
-    });
-
-    await waitFor(() => {
-      expect(dbMock.addresses.put).toHaveBeenCalledWith({
-        streetId: 1,
-        propertyTypeId: createdType!.id!,
-        numberStart: 300,
-        numberEnd: 400,
-        lastSuccessfulVisit: null,
-        nextVisitAllowed: null,
-      });
-    });
-  });
-
-  it('focuses the addresses tab via annotator callbacks and saves new addresses', async () => {
-    render(<RuasNumeracoesPage />);
-
-    await waitFor(() => {
-      expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('Rua Principal')).toBeTruthy();
-    });
-
-    const streetsTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.streets' });
-    const addressesTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.addresses' });
-
-    expect(streetsTab.className).toContain('font-bold');
-
-    await act(async () => {
-      screen.getByTestId('annotator-add').dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(addressesTab.className).toContain('font-bold');
-
-    await act(async () => {
-      streetsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(streetsTab.className).toContain('font-bold');
-
-    await act(async () => {
-      screen.getByTestId('annotator-update').dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(addressesTab.className).toContain('font-bold');
-
-    await act(async () => {
-      streetsTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(streetsTab.className).toContain('font-bold');
-
-    await act(async () => {
-      screen.getByTestId('annotator-delete').dispatchEvent(new MouseEvent('click', { bubbles: true }));
-    });
-    expect(addressesTab.className).toContain('font-bold');
-
-    const streetSelect = document.querySelector('select[name="streetId"]') as HTMLSelectElement | null;
-    const propertyTypeSelect = document.querySelector('select[name="propertyTypeId"]') as HTMLSelectElement | null;
-
-    expect(streetSelect).not.toBeNull();
-    expect(propertyTypeSelect).not.toBeNull();
-
-    await act(async () => {
-      streetSelect!.value = '1';
-      streetSelect!.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    await act(async () => {
-      propertyTypeSelect!.value = '10';
-      propertyTypeSelect!.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    const numberStartInput = screen.getByPlaceholderText(
-      'ruasNumeracoes.addressesForm.numberStart',
-    ) as HTMLInputElement;
-    const numberEndInput = screen.getByPlaceholderText(
-      'ruasNumeracoes.addressesForm.numberEnd',
-    ) as HTMLInputElement;
-
-    await act(async () => {
-      numberStartInput.value = '100';
-      numberStartInput.dispatchEvent(new Event('input', { bubbles: true }));
-      numberStartInput.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    await act(async () => {
-      numberEndInput.value = '200';
-      numberEndInput.dispatchEvent(new Event('input', { bubbles: true }));
-      numberEndInput.dispatchEvent(new Event('change', { bubbles: true }));
-    });
-
-    const saveButton = screen.getByRole('button', { name: 'common.save' }) as HTMLButtonElement;
-
-    await act(async () => {
-      saveButton.click();
-      await Promise.resolve();
-    });
-
-    await waitFor(() => {
-      expect(dbMock.addresses.put).toHaveBeenCalled();
-    });
-
-    await waitFor(() => {
-      expect(screen.getByText('200')).toBeTruthy();
-    });
-
-    expect(dbMock.addresses.put).toHaveBeenCalledWith({
-      streetId: 1,
-      propertyTypeId: 10,
-      numberStart: 100,
-      numberEnd: 200,
-      lastSuccessfulVisit: null,
-      nextVisitAllowed: null,
-    });
-  });
-
-  it('filters addresses for the active territory and updates the summary counts', async () => {
-    addressesStore.push({
-      id: 6,
-      streetId: 2,
-      numberStart: 20,
-      numberEnd: 30,
-      propertyTypeId: 20,
-      lastSuccessfulVisit: null,
-      nextVisitAllowed: null,
-    });
-
-    const originalImplementation = dbMock.addresses.where.getMockImplementation();
-
-      dbMock.addresses.where.mockImplementation((_field: keyof Address) => {
-        void _field;
-        return {
-          anyOf: () => ({
-            async toArray() {
-              // Return all addresses regardless of the provided filter to simulate stale data.
-              return addressesStore.map((address) => ({ ...address }));
-            },
-          }),
-        };
-      });
-
-    try {
-      render(<RuasNumeracoesPage />);
-
-      await waitFor(() => {
-        expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('Rua Principal')).toBeTruthy();
-      });
-
-      const addressesTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.addresses' });
-
-      await act(async () => {
-        addressesTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-
-      expect(screen.getByText('Rua Principal')).toBeTruthy();
-      expect(screen.queryByText('Avenida Secundária')).toBeNull();
-
-      const summaryTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.summary' });
-
-      await act(async () => {
-        summaryTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-
-      expect(screen.getByText('ruasNumeracoes.summary.totalStreets (1)')).toBeTruthy();
-      expect(screen.getByText('ruasNumeracoes.summary.totalAddresses (1)')).toBeTruthy();
-      expect(screen.getByText('ruasNumeracoes.summary.totalPropertyTypes (1)')).toBeTruthy();
-    } finally {
-      if (originalImplementation) {
-        dbMock.addresses.where.mockImplementation(originalImplementation);
-      } else {
-        dbMock.addresses.where.mockImplementation(defaultAddressesWhere);
-      }
-    }
-  });
-
-  it('marks a successful visit and enforces the cooldown state', async () => {
-    vi.useFakeTimers();
-    const now = new Date('2024-05-01T12:00:00.000Z');
-    vi.setSystemTime(now);
-
-    try {
-      render(<RuasNumeracoesPage />);
-
-      await waitFor(() => {
-        expect(territorioRepositoryMock.forPublisher).toHaveBeenCalledWith('publisher-1');
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('Rua Principal')).toBeTruthy();
-      });
-
-      const addressesTab = screen.getByRole('button', { name: 'ruasNumeracoes.tabs.addresses' });
-
-      await act(async () => {
-        addressesTab.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-      });
-
-      const markButton = screen.getByRole('button', {
-        name: 'ruasNumeracoes.addressesTable.markVisit',
-      }) as HTMLButtonElement;
-
-      expect(markButton.disabled).toBe(false);
-
-      await act(async () => {
-        markButton.dispatchEvent(new MouseEvent('click', { bubbles: true }));
-        await Promise.resolve();
-      });
-
-      const expectedLastVisit = now.toISOString();
-      const expectedNextVisit = new Date(now.getTime() + ADDRESS_VISIT_COOLDOWN_MS).toISOString();
-
-      await waitFor(() => {
-        expect(dbMock.addresses.put).toHaveBeenCalledWith(
-          expect.objectContaining({
-            id: 5,
-            streetId: 1,
-            numberStart: 1,
-            numberEnd: 10,
-            propertyTypeId: 10,
-            lastSuccessfulVisit: expectedLastVisit,
-            nextVisitAllowed: expectedNextVisit,
-          }),
-        );
-      });
-
-      await waitFor(() => {
-        expect(screen.getByText('ruasNumeracoes.addressesTable.cooldownAlert (1)')).toBeTruthy();
-      });
-
-      const disabledButton = screen.getByRole('button', {
-        name: 'ruasNumeracoes.addressesTable.markVisit',
-      }) as HTMLButtonElement;
-
-      expect(disabledButton.disabled).toBe(true);
-      expect(disabledButton.title).toBe('ruasNumeracoes.addressesTable.cooldownTooltip');
-      expect(screen.getByText('ruasNumeracoes.addressesTable.cooldownActive')).toBeTruthy();
-    } finally {
-      vi.useRealTimers();
-    }
+    expect(screen.getByText('ruasNumeracoes.summary.totalStreets (1)')).toBeTruthy();
+    expect(screen.getByText('ruasNumeracoes.summary.totalPropertyTypes (2)')).toBeTruthy();
+    expect(screen.queryByText('ruasNumeracoes.summary.totalAddresses')).toBeNull();
   });
 });

--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -1,31 +1,13 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
-import { z } from 'zod';
-import { zodResolver } from '@hookform/resolvers/zod';
 import type { Territorio } from '../types/territorio';
 import type { Street } from '../types/street';
 import type { PropertyType } from '../types/property-type';
-import type { Address } from '../types/address';
-import { ADDRESS_VISIT_COOLDOWN_MS } from '../constants/addresses';
 import { db } from '../services/db';
 import { TerritorioRepository } from '../services/repositories/territorios';
 import { useToast } from '../components/feedback/Toast';
 import { useAuth } from '../hooks/useAuth';
 import ImageAnnotator from '../components/ImageAnnotator';
-
-// schema and form types
-export const addressSchema = z.object({
-  id: z.number().optional(),
-  streetId: z.coerce.number(),
-  numberStart: z.coerce.number(),
-  numberEnd: z.coerce.number(),
-  propertyTypeId: z.coerce.number(),
-  lastSuccessfulVisit: z.string().nullable().optional(),
-  nextVisitAllowed: z.string().nullable().optional()
-});
-
-export type AddressForm = z.infer<typeof addressSchema>;
 
 export default function RuasNumeracoesPage(): JSX.Element {
   const { t } = useTranslation();
@@ -34,8 +16,7 @@ export default function RuasNumeracoesPage(): JSX.Element {
   const [territories, setTerritories] = useState<Territorio[]>([]);
   const [streets, setStreets] = useState<Street[]>([]);
   const [propertyTypes, setPropertyTypes] = useState<PropertyType[]>([]);
-  const [addresses, setAddresses] = useState<Address[]>([]);
-  const [activeTab, setActiveTab] = useState<'ruas' | 'enderecos' | 'tipos' | 'resumo'>('ruas');
+  const [activeTab, setActiveTab] = useState<'ruas' | 'tipos' | 'resumo'>('ruas');
   const [editingPropertyTypeId, setEditingPropertyTypeId] = useState<number | null>(null);
   const [editingPropertyTypeName, setEditingPropertyTypeName] = useState<string>('');
   const [territoryId, setTerritoryId] = useState<string>('');
@@ -52,71 +33,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
     [streets, territoryId]
   );
 
-  const allowedStreetIds = useMemo(() => {
-    const ids = new Set<number>();
-    for (const street of territoryStreets) {
-      if (typeof street.id === 'number') {
-        ids.add(street.id);
-      }
-    }
-    return ids;
-  }, [territoryStreets]);
-
-  const filteredAddresses = useMemo(
-    () => addresses.filter(address => allowedStreetIds.has(address.streetId)),
-    [addresses, allowedStreetIds]
-  );
-
-  const filteredPropertyTypeCount = useMemo(() => {
-    const uniquePropertyTypes = new Set<number>();
-    for (const address of filteredAddresses) {
-      uniquePropertyTypes.add(address.propertyTypeId);
-    }
-    return uniquePropertyTypes.size;
-  }, [filteredAddresses]);
-
-  const isAddressOnCooldown = useCallback((address: Address): boolean => {
-    const nextVisit = address.nextVisitAllowed;
-    if (!nextVisit) {
-      return false;
-    }
-    const parsed = new Date(nextVisit);
-    return !Number.isNaN(parsed.getTime()) && parsed.getTime() > Date.now();
-  }, []);
-
-  const lockedAddresses = useMemo(
-    () => filteredAddresses.filter(isAddressOnCooldown),
-    [filteredAddresses, isAddressOnCooldown]
-  );
-
-  const formatLastVisit = useCallback(
-    (value: string | null | undefined): string => {
-      if (!value) {
-        return t('ruasNumeracoes.addressesTable.neverVisited');
-      }
-      const date = new Date(value);
-      if (Number.isNaN(date.getTime())) {
-        return t('ruasNumeracoes.addressesTable.neverVisited');
-      }
-      return date.toLocaleString();
-    },
-    [t]
-  );
-
-  const formatNextVisit = useCallback(
-    (value: string | null | undefined): string => {
-      if (!value) {
-        return t('ruasNumeracoes.addressesTable.cooldownNotScheduled');
-      }
-      const date = new Date(value);
-      if (Number.isNaN(date.getTime())) {
-        return t('ruasNumeracoes.addressesTable.cooldownNotScheduled');
-      }
-      return date.toLocaleString();
-    },
-    [t]
-  );
-
   const refreshPropertyTypes = useCallback(async (): Promise<void> => {
     const propertyTypesData = await db.propertyTypes.toArray();
     setPropertyTypes(propertyTypesData);
@@ -126,14 +42,12 @@ export default function RuasNumeracoesPage(): JSX.Element {
     async (id: string, publisher: string | null): Promise<void> => {
       if (!id || !publisher) {
         setStreets([]);
-        setAddresses([]);
         return;
       }
 
       const matchingTerritory = territories.find(territoryItem => territoryItem.id === id);
       if (!matchingTerritory || matchingTerritory.publisherId !== publisher) {
         setStreets([]);
-        setAddresses([]);
         return;
       }
 
@@ -142,26 +56,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
         return;
       }
       setStreets(territoryStreets);
-
-      const streetIds = territoryStreets
-        .map(street => street.id)
-        .filter((streetId): streetId is number => streetId !== undefined);
-
-      if (streetIds.length === 0) {
-        if (territoryIdRef.current === id) {
-          setAddresses([]);
-        }
-        return;
-      }
-
-      const territoryAddresses = await db.addresses
-        .where('streetId')
-        .anyOf(streetIds)
-        .toArray();
-      if (territoryIdRef.current !== id) {
-        return;
-      }
-      setAddresses(territoryAddresses);
     },
     [territories]
   );
@@ -178,7 +72,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
           setTerritories([]);
           setPropertyTypes([]);
           setStreets([]);
-          setAddresses([]);
           setTerritoryId('');
           return;
         }
@@ -209,7 +102,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
 
         if (territoriesData.length === 0) {
           setStreets([]);
-          setAddresses([]);
         }
       } catch (error) {
         console.error(error);
@@ -219,7 +111,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
         setTerritories([]);
         setPropertyTypes([]);
         setStreets([]);
-        setAddresses([]);
         setTerritoryId('');
         toast.error(t('ruasNumeracoes.feedback.loadError'));
       }
@@ -236,62 +127,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
     territoryIdRef.current = territoryId;
     void refreshTerritoryData(territoryId, publisherId);
   }, [territoryId, refreshTerritoryData, publisherId]);
-
-  // address form
-  const {
-    register,
-    handleSubmit,
-    reset
-  } = useForm<AddressForm>({
-    resolver: zodResolver(addressSchema)
-  });
-
-  const saveAddress = async (data: AddressForm): Promise<void> => {
-    const currentPublisherId = publisherId;
-    if (!currentPublisherId || !territory || territory.publisherId !== currentPublisherId) {
-      return;
-    }
-
-    await db.addresses.put({
-      ...data,
-      lastSuccessfulVisit: data.lastSuccessfulVisit ?? null,
-      nextVisitAllowed: data.nextVisitAllowed ?? null
-    });
-    await refreshTerritoryData(territoryId, currentPublisherId);
-    reset();
-  };
-
-  const handleMarkSuccessfulVisit = useCallback(
-    async (address: Address): Promise<void> => {
-      if (address.id === undefined) {
-        return;
-      }
-
-      const currentPublisherId = publisherId;
-      const currentTerritoryId = territoryIdRef.current ?? '';
-      if (!currentPublisherId) {
-        return;
-      }
-
-      const matchingTerritory = territories.find(item => item.id === currentTerritoryId);
-      if (!matchingTerritory || matchingTerritory.publisherId !== currentPublisherId) {
-        return;
-      }
-
-      const now = new Date();
-      const lastSuccessfulVisit = now.toISOString();
-      const nextVisitAllowed = new Date(now.getTime() + ADDRESS_VISIT_COOLDOWN_MS).toISOString();
-
-      await db.addresses.put({
-        ...address,
-        lastSuccessfulVisit,
-        nextVisitAllowed
-      });
-
-      await refreshTerritoryData(currentTerritoryId, currentPublisherId);
-    },
-    [publisherId, refreshTerritoryData, territories]
-  );
 
   const saveStreet = async (event: React.FormEvent<HTMLFormElement>): Promise<void> => {
     event.preventDefault();
@@ -393,32 +228,11 @@ export default function RuasNumeracoesPage(): JSX.Element {
     [cancelEditPropertyType, editingPropertyTypeId, refreshPropertyTypes, t, toast]
   );
 
-  const focusAddressesTab = (): void => {
-    setActiveTab('enderecos');
-  };
-
-  const handleAnnotatorAdd = (): void => {
-    focusAddressesTab();
-  };
-
-  const handleAnnotatorUpdate = (): void => {
-    focusAddressesTab();
-  };
-
-  const handleAnnotatorDelete = (): void => {
-    focusAddressesTab();
-  };
-
   return (
     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <div className="border rounded p-2">
         {territory && (
-          <ImageAnnotator
-            imageUrl={territory.imageUrl ?? territory.imagem ?? ''}
-            onAdd={handleAnnotatorAdd}
-            onUpdate={handleAnnotatorUpdate}
-            onDelete={handleAnnotatorDelete}
-          />
+          <ImageAnnotator imageUrl={territory.imageUrl ?? territory.imagem ?? ''} />
         )}
       </div>
       <div className="flex flex-col gap-4">
@@ -448,13 +262,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
             onClick={() => setActiveTab('ruas')}
           >
             {t('ruasNumeracoes.tabs.streets')}
-          </button>
-          <button
-            type="button"
-            className={activeTab === 'enderecos' ? 'font-bold' : ''}
-            onClick={() => setActiveTab('enderecos')}
-          >
-            {t('ruasNumeracoes.tabs.addresses')}
           </button>
           <button
             type="button"
@@ -501,140 +308,6 @@ export default function RuasNumeracoesPage(): JSX.Element {
                       <td>{s.name}</td>
                     </tr>
                   ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        )}
-        {activeTab === 'enderecos' && (
-          <div>
-            <form
-              onSubmit={handleSubmit(saveAddress)}
-              className="mb-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-5"
-            >
-              <select
-                {...register('streetId', { valueAsNumber: true })}
-                className="border p-1 w-full sm:col-span-2 lg:col-span-2"
-              >
-                <option value="">{t('ruasNumeracoes.addressesForm.selectStreet')}</option>
-                {territoryStreets.map(s => (
-                  <option key={s.id} value={s.id}>
-                    {s.name}
-                  </option>
-                ))}
-              </select>
-              <select
-                {...register('propertyTypeId', { valueAsNumber: true })}
-                className="border p-1 w-full sm:col-span-2 lg:col-span-1"
-              >
-                <option value="">{t('ruasNumeracoes.addressesForm.selectType')}</option>
-                {propertyTypes.map((pt, index) => (
-                  <option key={pt.id ?? `${pt.name}-${index}`} value={pt.id}>
-                    {pt.name}
-                  </option>
-                ))}
-              </select>
-              <input
-                type="number"
-                placeholder={t('ruasNumeracoes.addressesForm.numberStart')}
-                className="border p-1 w-full sm:col-span-1 lg:col-span-1 lg:max-w-[7rem]"
-                {...register('numberStart', { valueAsNumber: true })}
-              />
-              <input
-                type="number"
-                placeholder={t('ruasNumeracoes.addressesForm.numberEnd')}
-                className="border p-1 w-full sm:col-span-1 lg:col-span-1 lg:max-w-[7rem]"
-                {...register('numberEnd', { valueAsNumber: true })}
-              />
-              <button
-                type="submit"
-                className="border px-2 py-1 w-full sm:col-span-2 sm:w-auto sm:justify-self-start lg:col-span-1"
-              >
-                {t('common.save')}
-              </button>
-            </form>
-            {lockedAddresses.length > 0 && (
-              <div className="mb-2 rounded border border-yellow-400 bg-yellow-50 p-2 text-sm text-yellow-800">
-                {t('ruasNumeracoes.addressesTable.cooldownAlert', { count: lockedAddresses.length })}
-              </div>
-            )}
-            <div className="overflow-x-auto">
-              <table className="w-full min-w-[720px] text-sm">
-                <thead>
-                  <tr>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.street')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.start')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.end')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.type')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.lastVisit')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.nextVisit')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.actions')}
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {filteredAddresses.map(a => {
-                    const isCooldown = isAddressOnCooldown(a);
-                    const cooldownTooltip = isCooldown
-                      ? t('ruasNumeracoes.addressesTable.cooldownTooltip', {
-                          date: formatNextVisit(a.nextVisitAllowed ?? null)
-                        })
-                      : undefined;
-
-                    return (
-                      <tr key={a.id}>
-                        <td className="px-2 py-1 whitespace-nowrap">
-                          {territoryStreets.find(s => s.id === a.streetId)?.name}
-                        </td>
-                        <td className="px-2 py-1 whitespace-nowrap">{a.numberStart}</td>
-                        <td className="px-2 py-1 whitespace-nowrap">{a.numberEnd}</td>
-                        <td className="px-2 py-1 whitespace-nowrap">
-                          {propertyTypes.find(pt => pt.id === a.propertyTypeId)?.name}
-                        </td>
-                        <td className="px-2 py-1 whitespace-nowrap">
-                          {formatLastVisit(a.lastSuccessfulVisit ?? null)}
-                        </td>
-                        <td className="px-2 py-1 whitespace-nowrap">
-                          {formatNextVisit(a.nextVisitAllowed ?? null)}
-                        </td>
-                        <td className="min-w-[12rem] px-2 py-1 align-top">
-                          <div className="flex flex-col gap-1 sm:flex-row sm:flex-wrap">
-                            <button
-                              type="button"
-                              className="border px-2 py-1 w-full disabled:cursor-not-allowed disabled:opacity-50 sm:w-auto"
-                              onClick={() => {
-                                void handleMarkSuccessfulVisit(a);
-                              }}
-                              disabled={isCooldown}
-                              title={cooldownTooltip}
-                            >
-                              {t('ruasNumeracoes.addressesTable.markVisit')}
-                            </button>
-                            {isCooldown && (
-                              <p className="text-xs text-yellow-700 sm:basis-full">
-                                {t('ruasNumeracoes.addressesTable.cooldownActive', {
-                                  date: formatNextVisit(a.nextVisitAllowed ?? null)
-                                })}
-                              </p>
-                            )}
-                          </div>
-                        </td>
-                      </tr>
-                    );
-                  })}
                 </tbody>
               </table>
             </div>
@@ -756,13 +429,8 @@ export default function RuasNumeracoesPage(): JSX.Element {
               })}
             </p>
             <p>
-              {t('ruasNumeracoes.summary.totalAddresses', {
-                count: filteredAddresses.length
-              })}
-            </p>
-            <p>
               {t('ruasNumeracoes.summary.totalPropertyTypes', {
-                count: filteredPropertyTypeCount
+                count: propertyTypes.length
               })}
             </p>
           </div>

--- a/src/pages/streetsPublisherScoping.test.tsx
+++ b/src/pages/streetsPublisherScoping.test.tsx
@@ -3,7 +3,6 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 
 import type { Territorio } from '../types/territorio';
 import type { Street } from '../types/street';
-import type { Address } from '../types/address';
 
 const {
   useAuthMock,
@@ -31,29 +30,7 @@ const {
     { id: 2, territoryId: 'territory-2', name: 'Rua Sul 1' },
   ];
 
-  const addressesSeed: Address[] = [
-    {
-      id: 100,
-      streetId: 1,
-      numberStart: 1,
-      numberEnd: 10,
-      propertyTypeId: 10,
-      lastSuccessfulVisit: null,
-      nextVisitAllowed: null,
-    },
-    {
-      id: 200,
-      streetId: 2,
-      numberStart: 20,
-      numberEnd: 30,
-      propertyTypeId: 10,
-      lastSuccessfulVisit: null,
-      nextVisitAllowed: null,
-    },
-  ];
-
   const requestedStreetTerritories: string[] = [];
-  const requestedAddressStreetIds: number[][] = [];
 
   const useAuthMock = vi.fn(() => ({
     currentUser,
@@ -93,22 +70,6 @@ const {
       })),
       put: vi.fn(),
     },
-    addresses: {
-      where: vi.fn((field: keyof Address) => ({
-        anyOf: (values: number[]) => {
-          requestedAddressStreetIds.push(values);
-          return {
-            async toArray() {
-              const allowed = new Set(values);
-              return addressesSeed
-                .filter((address) => allowed.has(address[field] as number))
-                .map((address) => ({ ...address }));
-            },
-          };
-        },
-      })),
-      put: vi.fn(),
-    },
   };
 
   const translationMock = {
@@ -122,7 +83,6 @@ const {
     dbMock,
     translationMock,
     requestedStreetTerritories,
-    requestedAddressStreetIds,
   };
 });
 
@@ -159,11 +119,10 @@ describe('RuasNumeracoesPage publisher scoping', () => {
   afterEach(() => {
     cleanup();
     requestedStreetTerritories.length = 0;
-    requestedAddressStreetIds.length = 0;
     vi.clearAllMocks();
   });
 
-  it('loads only the current publisher territories, streets and addresses', async () => {
+  it('loads only the current publisher territories and streets', async () => {
     render(<RuasNumeracoesPage />);
 
     await waitFor(() => {
@@ -182,6 +141,5 @@ describe('RuasNumeracoesPage publisher scoping', () => {
     expect(screen.queryByText('Rua Sul 1')).toBeNull();
 
     expect(requestedStreetTerritories).toEqual(['territory-1']);
-    expect(requestedAddressStreetIds).toEqual([[1]]);
   });
 });


### PR DESCRIPTION
## Summary
- remove the addresses tab and related state/handlers from RuasNumeracoesPage so the screen now focuses on streets and property types
- simplify the summary panel to report streets and property types only and stop reacting to annotator events
- update unit tests to reflect the reduced scope of the page and adjust publisher scoping expectations

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd55e167288325a14751fbbd048935