### PR TITLE
feat: secure user authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ VITE_NOTIFICATIONS_API_URL="https://sua-api.com"
 
 Quando essa variável não estiver definida, as notificações de devolução permanecerão apenas no modo offline.
 
+As credenciais padrão do usuário administrador podem ser personalizadas com as variáveis abaixo:
+
+```bash
+VITE_ADMIN_MASTER_NAME="Nome exibido"
+VITE_ADMIN_MASTER_EMAIL="admin@exemplo.com"
+VITE_ADMIN_MASTER_PASSWORD="sua_senha_segura"
+```
+
+Por padrão o usuário `admin_master` é criado com a senha `assigna123`. Recomenda-se alterar essas credenciais em produção.
+
+## Autenticação
+
+- O login requer um identificador (ID do usuário ou e-mail) e senha.
+- Um usuário inicial `admin_master` é criado automaticamente para acesso administrativo.
+- A senha padrão é `assigna123` e pode ser ajustada pelas variáveis de ambiente listadas acima.
+- As senhas são armazenadas como hash SHA-256 e podem ser atualizadas ao editar o usuário em **Usuários**.
+
 ## Internacionalização (i18n)
 - Idiomas suportados: `en-US`, `pt-BR` e `es-ES`.
 - O idioma selecionado persiste em `localStorage` sob a chave `locale`.
@@ -82,7 +99,7 @@ Quando essa variável não estiver definida, as notificações de devolução pe
 
 ## Banco de Dados (Offline)
 - Todos os dados são armazenados no **IndexedDB** via **Dexie.js** (`src/services/db.ts`).
-- Migrações de esquema são aplicadas automaticamente ao abrir a aplicação. A versão atual é controlada pela constante `SCHEMA_VERSION`, definida em [`src/services/db.ts`](src/services/db.ts) (atualmente em 10).
+- Migrações de esquema são aplicadas automaticamente ao abrir a aplicação. A versão atual é controlada pela constante `SCHEMA_VERSION`, definida em [`src/services/db.ts`](src/services/db.ts) (atualmente em 11).
 - Campos de visitas em endereços: `lastSuccessfulVisit` e `nextVisitAllowed`.
 
 ## Screenshots

--- a/src/AppContent.test.tsx
+++ b/src/AppContent.test.tsx
@@ -14,7 +14,7 @@ vi.mock('react-i18next', () => ({
 const mockAuthState = {
   currentUser: null as AuthUser | null,
   isAuthenticated: false,
-  signIn: vi.fn(),
+  signIn: vi.fn().mockResolvedValue(null),
   signOut: vi.fn(),
 };
 
@@ -70,6 +70,7 @@ describe('AppContent scheduler controls visibility', () => {
   beforeEach(() => {
     mockAuthState.currentUser = null;
     mockAuthState.isAuthenticated = false;
+    mockAuthState.signIn.mockResolvedValue(null);
   });
 
   afterEach(() => {

--- a/src/constants/auth.ts
+++ b/src/constants/auth.ts
@@ -1,0 +1,30 @@
+import { ADMIN_MASTER_ROLE } from './roles';
+
+const getEnvVar = (key: string): string | undefined => {
+  const metaEnv =
+    typeof import.meta !== 'undefined' && (import.meta as { env?: Record<string, unknown> }).env;
+  if (metaEnv) {
+    const value = metaEnv[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  if (typeof process !== 'undefined' && typeof process.env === 'object') {
+    const value = process.env[key];
+    if (typeof value === 'string') {
+      return value;
+    }
+  }
+
+  return undefined;
+};
+
+export const ADMIN_MASTER_USERNAME = 'admin_master' as const;
+export const ADMIN_MASTER_DEFAULT_NAME =
+  getEnvVar('VITE_ADMIN_MASTER_NAME') ?? 'Administrador Master';
+export const ADMIN_MASTER_DEFAULT_EMAIL =
+  getEnvVar('VITE_ADMIN_MASTER_EMAIL') ?? 'admin_master@example.com';
+export const ADMIN_MASTER_DEFAULT_PASSWORD =
+  getEnvVar('VITE_ADMIN_MASTER_PASSWORD') ?? 'assigna123';
+export const ADMIN_MASTER_DEFAULT_ROLE = ADMIN_MASTER_ROLE;

--- a/src/hooks/contextHooks.test.ts
+++ b/src/hooks/contextHooks.test.ts
@@ -30,6 +30,8 @@ function createRepositoryMock() {
     clear: vi.fn().mockResolvedValue(undefined),
     bulkAdd: vi.fn().mockResolvedValue(undefined),
     all: vi.fn().mockResolvedValue([]),
+    findById: vi.fn().mockResolvedValue(undefined),
+    findByEmail: vi.fn().mockResolvedValue(undefined),
     forPublisher: vi.fn().mockResolvedValue([]),
   };
 }
@@ -119,6 +121,7 @@ const createAppState = (): AppState => ({
       name: 'Alice',
       email: 'alice@example.com',
       role: 'admin',
+      passwordHash: 'hash-1',
       createdAt: '2024-01-01T00:00:00.000Z',
       updatedAt: '2024-01-02T00:00:00.000Z',
     },
@@ -379,7 +382,12 @@ describe('App context hooks', () => {
       const selectSpy = vi.spyOn(selectors, 'selectUsers').mockReturnValue(state.users);
 
       const { addUser } = useUsers();
-      await addUser({ name: 'Charlie', email: 'charlie@example.com', role: 'manager' });
+      await addUser({
+        name: 'Charlie',
+        email: 'charlie@example.com',
+        role: 'manager',
+        password: 'secret123',
+      });
 
       expect(mockedUseContext).toHaveBeenCalledWith(AppContext);
       expect(dispatch).toHaveBeenCalledWith(

--- a/src/hooks/useUsers.ts
+++ b/src/hooks/useUsers.ts
@@ -6,6 +6,15 @@ import type { User } from '../types/user';
 import { UserRepository } from '../services/repositories';
 import { useToast } from '../components/feedback/Toast';
 import { generateId } from '../utils/id';
+import { hashPassword } from '../utils/password';
+
+type NewUserInput = Omit<User, 'id' | 'createdAt' | 'updatedAt' | 'passwordHash'> & {
+  password: string;
+};
+
+type UpdateUserInput = Omit<User, 'id' | 'createdAt' | 'updatedAt' | 'passwordHash'> & {
+  password?: string | null;
+};
 
 export const useUsers = () => {
   const { state, dispatch } = useApp();
@@ -16,9 +25,22 @@ export const useUsers = () => {
   return {
     users,
     addUser: useCallback(
-      async (user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>) => {
+      async (user: NewUserInput) => {
         const now = new Date().toISOString();
-        const record: User = { id: generateId(), createdAt: now, updatedAt: now, ...user };
+        const password = user.password.trim();
+        if (!password) {
+          throw new Error('PASSWORD_REQUIRED');
+        }
+        const passwordHash = await hashPassword(password);
+        const { password: _password, ...userWithoutPassword } = user;
+        void _password;
+        const record: User = {
+          id: generateId(),
+          createdAt: now,
+          updatedAt: now,
+          passwordHash,
+          ...userWithoutPassword,
+        };
         await UserRepository.add(record);
         dispatch({ type: 'ADD_USER', payload: record });
         toast.success(t('users.toast.createSuccess'));
@@ -27,10 +49,22 @@ export const useUsers = () => {
       [dispatch, t, toast]
     ),
     updateUser: useCallback(
-      async (id: string, user: Omit<User, 'id' | 'createdAt' | 'updatedAt'>) => {
+      async (id: string, user: UpdateUserInput) => {
         const existing = users.find((item) => item.id === id);
         const createdAt = existing?.createdAt ?? new Date().toISOString();
-        const record: User = { id, createdAt, updatedAt: new Date().toISOString(), ...user };
+        const password = user.password?.trim();
+        const passwordHash = password && password.length > 0
+          ? await hashPassword(password)
+          : existing?.passwordHash ?? '';
+        const { password: _password, ...userWithoutPassword } = user;
+        void _password;
+        const record: User = {
+          id,
+          createdAt,
+          updatedAt: new Date().toISOString(),
+          passwordHash,
+          ...userWithoutPassword,
+        };
         await UserRepository.update(record);
         dispatch({ type: 'UPDATE_USER', payload: record });
         toast.success(t('users.toast.updateSuccess'));

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -286,6 +286,13 @@
       "name": "Name",
       "email": "Email",
       "role": "Role",
+      "password": "Password",
+      "passwordPlaceholder": "Set a secure password",
+      "passwordConfirmation": "Confirm password",
+      "passwordConfirmationPlaceholder": "Repeat the password",
+      "passwordHint": "Fill both fields to set or update the password. Leave them blank to keep the current one.",
+      "passwordRequired": "Please provide a password.",
+      "passwordMismatch": "Passwords do not match.",
       "namePlaceholder": "Full name",
       "emailPlaceholder": "name@example.com",
       "save": "Save user",
@@ -303,7 +310,8 @@
     "toast": {
       "createSuccess": "User saved",
       "updateSuccess": "User updated",
-      "deleteSuccess": "User removed"
+      "deleteSuccess": "User removed",
+      "saveError": "Unable to save the user."
     },
     "roles": {
       "admin_master": "Admin master",
@@ -430,6 +438,15 @@
       "light": "Light",
       "dark": "Dark"
     }
+  },
+  "auth": {
+    "identifierLabel": "Identifier",
+    "identifierPlaceholder": "Username or email",
+    "passwordLabel": "Password",
+    "passwordPlaceholder": "Password",
+    "signIn": "Sign in",
+    "signOut": "Sign out",
+    "invalidCredentials": "Invalid credentials. Please check your details and try again."
   },
   "language": {
     "english": "English",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -284,6 +284,13 @@
       "name": "Nombre",
       "email": "Correo electrónico",
       "role": "Rol",
+      "password": "Contraseña",
+      "passwordPlaceholder": "Define una contraseña segura",
+      "passwordConfirmation": "Confirmar contraseña",
+      "passwordConfirmationPlaceholder": "Repite la contraseña",
+      "passwordHint": "Completa ambos campos para definir o actualizar la contraseña. Déjalos en blanco para mantener la actual.",
+      "passwordRequired": "Ingresa una contraseña.",
+      "passwordMismatch": "Las contraseñas no coinciden.",
       "namePlaceholder": "Nombre completo",
       "emailPlaceholder": "nombre@ejemplo.com",
       "save": "Guardar usuario",
@@ -301,7 +308,8 @@
     "toast": {
       "createSuccess": "Usuario guardado",
       "updateSuccess": "Usuario actualizado",
-      "deleteSuccess": "Usuario eliminado"
+      "deleteSuccess": "Usuario eliminado",
+      "saveError": "No se pudo guardar el usuario."
     },
     "roles": {
       "admin_master": "Administrador maestro",
@@ -428,6 +436,15 @@
       "light": "Claro",
       "dark": "Oscuro"
     }
+  },
+  "auth": {
+    "identifierLabel": "Identificación",
+    "identifierPlaceholder": "Usuario o correo",
+    "passwordLabel": "Contraseña",
+    "passwordPlaceholder": "Contraseña",
+    "signIn": "Iniciar sesión",
+    "signOut": "Cerrar sesión",
+    "invalidCredentials": "Credenciales no válidas. Verifica los datos e inténtalo de nuevo."
   },
   "language": {
     "english": "Inglés",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -288,6 +288,13 @@
       "name": "Nome",
       "email": "E-mail",
       "role": "Papel",
+      "password": "Senha",
+      "passwordPlaceholder": "Defina uma senha segura",
+      "passwordConfirmation": "Confirmar senha",
+      "passwordConfirmationPlaceholder": "Repita a senha",
+      "passwordHint": "Preencha ambos os campos para definir ou alterar a senha. Deixe em branco para manter a atual.",
+      "passwordRequired": "Informe uma senha.",
+      "passwordMismatch": "As senhas não coincidem.",
       "namePlaceholder": "Nome completo",
       "emailPlaceholder": "nome@exemplo.com",
       "save": "Salvar usuário",
@@ -305,7 +312,8 @@
     "toast": {
       "createSuccess": "Usuário salvo",
       "updateSuccess": "Usuário atualizado",
-      "deleteSuccess": "Usuário removido"
+      "deleteSuccess": "Usuário removido",
+      "saveError": "Não foi possível salvar o usuário."
     },
     "roles": {
       "admin_master": "Admin master",
@@ -432,6 +440,15 @@
       "light": "Claro",
       "dark": "Escuro"
     }
+  },
+  "auth": {
+    "identifierLabel": "Identificação",
+    "identifierPlaceholder": "Usuário ou e-mail",
+    "passwordLabel": "Senha",
+    "passwordPlaceholder": "Senha",
+    "signIn": "Entrar",
+    "signOut": "Sair",
+    "invalidCredentials": "Credenciais inválidas. Verifique os dados e tente novamente."
   },
   "language": {
     "english": "Inglês",

--- a/src/pages/RuasNumeracoesPage.test.tsx
+++ b/src/pages/RuasNumeracoesPage.test.tsx
@@ -178,7 +178,7 @@ beforeEach(() => {
       updatedAt: '2024-01-01T00:00:00.000Z'
     },
     isAuthenticated: true,
-    signIn: vi.fn(),
+    signIn: vi.fn().mockResolvedValue(null),
     signOut: vi.fn()
   });
 

--- a/src/services/data-transfer.ts
+++ b/src/services/data-transfer.ts
@@ -133,6 +133,7 @@ const userSchema = z.object({
   name: z.string(),
   email: z.string(),
   role: z.enum(AVAILABLE_ROLES),
+  passwordHash: z.string().optional().default(''),
   createdAt: z.string(),
   updatedAt: z.string()
 });

--- a/src/services/db.test.ts
+++ b/src/services/db.test.ts
@@ -9,6 +9,14 @@ import {
   DEFAULT_PROPERTY_TYPE_NAMES,
   ensureDefaultPropertyTypesSeeded
 } from './db';
+import {
+  ADMIN_MASTER_DEFAULT_PASSWORD,
+  ADMIN_MASTER_DEFAULT_ROLE,
+  ADMIN_MASTER_DEFAULT_NAME,
+  ADMIN_MASTER_DEFAULT_EMAIL,
+  ADMIN_MASTER_USERNAME
+} from '../constants/auth';
+import { hashPassword } from '../utils/password';
 import { TerritorioRepository, BuildingVillageRepository, NaoEmCasaRepository } from './repositories';
 import { ADDRESS_VISIT_COOLDOWN_MS } from '../constants/addresses';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
@@ -168,6 +176,17 @@ describe('IndexedDB persistence', () => {
     await BuildingVillageRepository.add(buildingVillage);
     const stored = await BuildingVillageRepository.forPublisher('publisher-migrate');
     expect(stored).toContainEqual(buildingVillage);
+
+    const adminUser = await db.users.get(ADMIN_MASTER_USERNAME);
+    expect(adminUser).toBeTruthy();
+    if (!adminUser) {
+      throw new Error('Admin user was not created during migration');
+    }
+    expect(adminUser.role).toBe(ADMIN_MASTER_DEFAULT_ROLE);
+    expect(adminUser.name).toBe(ADMIN_MASTER_DEFAULT_NAME);
+    expect(adminUser.email).toBe(ADMIN_MASTER_DEFAULT_EMAIL);
+    const expectedHash = await hashPassword(ADMIN_MASTER_DEFAULT_PASSWORD);
+    expect(adminUser.passwordHash).toBe(expectedHash);
   });
 
   it('ensures default property types exist without duplication', async () => {

--- a/src/services/import/index.ts
+++ b/src/services/import/index.ts
@@ -9,7 +9,7 @@ import {
   UserRepository
 } from '../repositories';
 import { BuildingVillageRepository } from '../repositories/buildings_villages';
-import { db, SCHEMA_VERSION } from '../db';
+import { db, SCHEMA_VERSION, ensureAdminMasterUserSeeded } from '../db';
 
 type ImportSource = File | Blob | string;
 
@@ -126,6 +126,8 @@ export const importData = async (source: ImportSource): Promise<ExportedData> =>
       await db.metadata.bulkPut(metadataRecords);
     }
   );
+
+  await ensureAdminMasterUserSeeded();
 
   return { ...data, metadata: metadataRecords, version: SCHEMA_VERSION };
 };

--- a/src/services/repositories/users.ts
+++ b/src/services/repositories/users.ts
@@ -1,9 +1,25 @@
 import type { User } from '../../types/user';
-import { db } from '../db';
+import { db, ensureAdminMasterUserSeeded } from '../db';
 
 export const UserRepository = {
   async all(): Promise<User[]> {
     return db.users.toArray();
+  },
+
+  async findById(id: string): Promise<User | undefined> {
+    const trimmed = id.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return db.users.get(trimmed);
+  },
+
+  async findByEmail(email: string): Promise<User | undefined> {
+    const trimmed = email.trim();
+    if (!trimmed) {
+      return undefined;
+    }
+    return db.users.where('email').equalsIgnoreCase(trimmed).first();
   },
 
   async add(user: User): Promise<void> {
@@ -27,5 +43,6 @@ export const UserRepository = {
 
   async clear(): Promise<void> {
     await db.users.clear();
+    await ensureAdminMasterUserSeeded();
   },
 };

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -5,6 +5,7 @@ export interface User {
   name: string;
   email: string;
   role: UserRole;
+  passwordHash: string;
   createdAt: string;
   updatedAt: string;
 }

--- a/src/utils/password.ts
+++ b/src/utils/password.ts
@@ -1,0 +1,92 @@
+const textEncoder = new TextEncoder();
+
+const bufferToHex = (buffer: ArrayBuffer): string => {
+  const bytes = new Uint8Array(buffer);
+  return Array.from(bytes)
+    .map((byte) => byte.toString(16).padStart(2, '0'))
+    .join('');
+};
+
+const hexToUint8Array = (hex: string): Uint8Array | null => {
+  const normalized = hex.trim().toLowerCase();
+  if (normalized.length === 0 || normalized.length % 2 !== 0) {
+    return null;
+  }
+
+  const length = normalized.length / 2;
+  const bytes = new Uint8Array(length);
+
+  for (let index = 0; index < length; index++) {
+    const start = index * 2;
+    const value = Number.parseInt(normalized.slice(start, start + 2), 16);
+    if (Number.isNaN(value)) {
+      return null;
+    }
+    bytes[index] = value;
+  }
+
+  return bytes;
+};
+
+const timingSafeEqual = (a: Uint8Array, b: Uint8Array): boolean => {
+  if (a.length !== b.length) {
+    return false;
+  }
+
+  let result = 0;
+  for (let index = 0; index < a.length; index++) {
+    result |= a[index] ^ b[index];
+  }
+  return result === 0;
+};
+
+const getSubtleCrypto = async (): Promise<SubtleCrypto> => {
+  const globalCrypto = (globalThis as { crypto?: Crypto & { webcrypto?: Crypto } }).crypto;
+  const subtle = globalCrypto?.subtle ?? globalCrypto?.webcrypto?.subtle;
+  if (subtle) {
+    return subtle;
+  }
+
+  if (typeof process !== 'undefined' && typeof process.versions?.node === 'string') {
+    const { webcrypto } = await import('node:crypto');
+    return webcrypto.subtle;
+  }
+
+  throw new Error('SubtleCrypto API is not available in this environment');
+};
+
+/**
+ * Generates a SHA-256 hash for a password using the Web Crypto API.
+ */
+export const hashPassword = async (password: string): Promise<string> => {
+  const subtle = await getSubtleCrypto();
+  const normalized = password.normalize('NFKC');
+  const data = textEncoder.encode(normalized);
+  const digest = await subtle.digest('SHA-256', data);
+  return bufferToHex(digest);
+};
+
+/**
+ * Verifies whether the provided password matches the stored hash.
+ */
+export const verifyPassword = async (
+  password: string,
+  expectedHash: string | null | undefined
+): Promise<boolean> => {
+  if (typeof expectedHash !== 'string' || expectedHash.trim().length === 0) {
+    return false;
+  }
+
+  const storedBytes = hexToUint8Array(expectedHash);
+  if (!storedBytes) {
+    return false;
+  }
+
+  const candidateHash = await hashPassword(password);
+  const candidateBytes = hexToUint8Array(candidateHash);
+  if (!candidateBytes) {
+    return false;
+  }
+
+  return timingSafeEqual(storedBytes, candidateBytes);
+};


### PR DESCRIPTION
## Summary
- adiciona utilitário de hashing de senha e constantes configuráveis para o usuário admin padrão
- atualiza o schema do Dexie para armazenar hash de senha, migra dados existentes e garante o seed do usuário admin_master
- habilita criação/edição de senha na página de usuários e validação de credenciais com hash no fluxo de login
- documenta as novas credenciais padrão e variáveis de ambiente no README

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd5e9fb3508325af95c8ddb3e02d81