### PR TITLE
Add guided tour for suggestion rules

### DIFF
--- a/src/components/feedback/GuidedTour.tsx
+++ b/src/components/feedback/GuidedTour.tsx
@@ -1,0 +1,184 @@
+import React, { useEffect, useLayoutEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useTranslation } from 'react-i18next';
+import { Button } from '../ui';
+
+export interface GuidedTourStep {
+  ref: React.RefObject<HTMLElement>;
+  title: string;
+  description: string;
+}
+
+interface GuidedTourProps {
+  steps: GuidedTourStep[];
+  open: boolean;
+  stepIndex: number;
+  onNext: () => void;
+  onPrevious: () => void;
+  onClose: () => void;
+}
+
+interface Position {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const HIGHLIGHT_PADDING = 12;
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export const GuidedTour: React.FC<GuidedTourProps> = ({ steps, open, stepIndex, onNext, onPrevious, onClose }) => {
+  const { t } = useTranslation();
+  const [position, setPosition] = useState<Position | null>(null);
+  const [tooltipPosition, setTooltipPosition] = useState<{ top: number; left: number } | null>(null);
+
+  const totalSteps = steps.length;
+  const isLastStep = stepIndex >= totalSteps - 1;
+  const isFirstStep = stepIndex <= 0;
+
+  const activeStep = steps[stepIndex];
+
+  const updatePosition = useMemo(
+    () => () => {
+      if (!open) {
+        return;
+      }
+
+      const element = steps[stepIndex]?.ref.current;
+      if (!element) {
+        setPosition(null);
+        setTooltipPosition(null);
+        return;
+      }
+
+      const rect = element.getBoundingClientRect();
+      const highlight: Position = {
+        top: rect.top - HIGHLIGHT_PADDING,
+        left: rect.left - HIGHLIGHT_PADDING,
+        width: rect.width + HIGHLIGHT_PADDING * 2,
+        height: rect.height + HIGHLIGHT_PADDING * 2,
+      };
+      setPosition(highlight);
+
+      const tooltipWidth = Math.min(320, window.innerWidth - 32);
+      const margin = 16;
+      let top = rect.bottom + margin;
+      if (top + 200 > window.innerHeight) {
+        top = rect.top - margin - 200;
+      }
+      top = clamp(top, 16, Math.max(16, window.innerHeight - 216));
+      const left = clamp(rect.left, 16, window.innerWidth - tooltipWidth - 16);
+      setTooltipPosition({ top, left });
+    },
+    [open, stepIndex, steps],
+  );
+
+  useLayoutEffect(() => {
+    if (!open) {
+      setPosition(null);
+      setTooltipPosition(null);
+      return;
+    }
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open, updatePosition]);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const element = steps[stepIndex]?.ref.current;
+    if (element) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'center' });
+    }
+    updatePosition();
+  }, [open, stepIndex, steps, updatePosition]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handler = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  if (!open || totalSteps === 0) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-[1000]">
+      <div className="absolute inset-0" onClick={onClose} />
+      {position && (
+        <div
+          className="pointer-events-none fixed rounded-2xl border-2 border-white shadow-[0_0_0_9999px_rgba(0,0,0,0.6)] transition-all duration-150"
+          style={{
+            top: Math.max(position.top, 8),
+            left: Math.max(position.left, 8),
+            width: Math.max(position.width, 40),
+            height: Math.max(position.height, 40),
+          }}
+        />
+      )}
+      <div className="fixed inset-0 flex items-start justify-center overflow-hidden pointer-events-none">
+        <div
+          className="relative w-full"
+          style={{
+            maxWidth: '100%',
+            height: '100%',
+          }}
+        >
+          {tooltipPosition && activeStep && (
+            <div
+              className="pointer-events-auto fixed z-[1001] max-w-[320px] rounded-2xl bg-white p-4 text-neutral-900 shadow-lg dark:bg-neutral-900 dark:text-neutral-100"
+              style={{ top: tooltipPosition.top, left: tooltipPosition.left }}
+            >
+              <div className="mb-2 text-xs uppercase tracking-wide text-neutral-500 dark:text-neutral-400">
+                {t('suggestions.tour.progress', { current: stepIndex + 1, total: totalSteps })}
+              </div>
+              <h3 className="text-lg font-semibold">{activeStep.title}</h3>
+              <p className="mt-1 text-sm text-neutral-600 dark:text-neutral-300">{activeStep.description}</p>
+              <div className="mt-4 flex flex-wrap gap-2">
+                <Button
+                  type="button"
+                  onClick={onPrevious}
+                  disabled={isFirstStep}
+                  className="bg-neutral-200 text-neutral-900 dark:bg-neutral-800 dark:text-neutral-100 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {t('common.previous')}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={onClose}
+                  className="ml-auto bg-transparent text-neutral-500 hover:text-neutral-700 dark:text-neutral-300"
+                >
+                  {t('app.close')}
+                </Button>
+                <Button
+                  type="button"
+                  onClick={isLastStep ? onClose : onNext}
+                  className="bg-black text-white dark:bg-white dark:text-black"
+                >
+                  {isLastStep ? t('suggestions.tour.finish') : t('common.next')}
+                </Button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+};
+

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -368,7 +368,8 @@
     "actions": {
       "saveDefaults": "Save defaults",
       "generate": "Generate Suggestions",
-      "applyAll": "Apply All"
+      "applyAll": "Apply All",
+      "viewTour": "View tour"
     },
     "labels": {
       "startDate": "Start date",
@@ -399,6 +400,10 @@
     "toast": {
       "nothingToApply": "Nothing to apply",
       "applied": "Suggestions applied"
+    },
+    "tour": {
+      "progress": "Step {{current}} of {{total}}",
+      "finish": "Finish tour"
     },
     "reasons": {
       "exitLoad": "Exit load {{value}}%",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -366,7 +366,8 @@
     "actions": {
       "saveDefaults": "Guardar valores predeterminados",
       "generate": "Generar sugerencias",
-      "applyAll": "Aplicar todo"
+      "applyAll": "Aplicar todo",
+      "viewTour": "Ver tour"
     },
     "labels": {
       "startDate": "Fecha inicial",
@@ -397,6 +398,10 @@
     "toast": {
       "nothingToApply": "Nada que aplicar",
       "applied": "Sugerencias aplicadas"
+    },
+    "tour": {
+      "progress": "Paso {{current}} de {{total}}",
+      "finish": "Finalizar tour"
     },
     "reasons": {
       "exitLoad": "Carga de salida {{value}}%",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -370,7 +370,8 @@
     "actions": {
       "saveDefaults": "Salvar padrões",
       "generate": "Gerar sugestões",
-      "applyAll": "Aplicar tudo"
+      "applyAll": "Aplicar tudo",
+      "viewTour": "Ver tour"
     },
     "labels": {
       "startDate": "Data inicial",
@@ -401,6 +402,10 @@
     "toast": {
       "nothingToApply": "Nada para aplicar",
       "applied": "Designações aplicadas"
+    },
+    "tour": {
+      "progress": "Passo {{current}} de {{total}}",
+      "finish": "Finalizar tour"
     },
     "reasons": {
       "exitLoad": "Carga saída {{value}}%",

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useToast } from '../components/feedback/Toast';
+import { GuidedTour, GuidedTourStep } from '../components/feedback/GuidedTour';
 import { Card, Button, Input, Label } from '../components/ui';
 import { useTerritorios } from '../hooks/useTerritorios';
 import { useSaidas } from '../hooks/useSaidas';
@@ -32,6 +33,66 @@ const SuggestionsPage: React.FC = () => {
   const [balanceWeight, setBalanceWeight] = useState<number>(rules.balanceWeight);
   const [generated, setGenerated] = useState<Suggestion[] | null>(null);
   const [rankings, setRankings] = useState<Record<string, { territorioId: string; score: number; reasons: string[] }[]>>({});
+  const [tourStep, setTourStep] = useState<number | null>(null);
+
+  const startDateRef = useRef<HTMLDivElement>(null);
+  const durationRef = useRef<HTMLDivElement>(null);
+  const avoidCountRef = useRef<HTMLDivElement>(null);
+  const monthsPerExitRef = useRef<HTMLDivElement>(null);
+  const recentWeightRef = useRef<HTMLDivElement>(null);
+  const balanceWeightRef = useRef<HTMLDivElement>(null);
+
+  const tourSteps: GuidedTourStep[] = useMemo(
+    () => [
+      {
+        ref: startDateRef,
+        title: t('suggestions.labels.startDate'),
+        description: t('suggestions.tooltips.startDate'),
+      },
+      {
+        ref: durationRef,
+        title: t('suggestions.labels.duration'),
+        description: t('suggestions.tooltips.duration'),
+      },
+      {
+        ref: avoidCountRef,
+        title: t('suggestions.labels.avoidCount'),
+        description: t('suggestions.tooltips.avoidCount'),
+      },
+      {
+        ref: monthsPerExitRef,
+        title: t('suggestions.labels.monthsPerExit'),
+        description: t('suggestions.tooltips.monthsPerExit'),
+      },
+      {
+        ref: recentWeightRef,
+        title: t('suggestions.labels.recentWeight'),
+        description: t('suggestions.tooltips.recentWeight'),
+      },
+      {
+        ref: balanceWeightRef,
+        title: t('suggestions.labels.balanceWeight'),
+        description: t('suggestions.tooltips.balanceWeight'),
+      },
+    ],
+    [t],
+  );
+
+  const isTourOpen = tourStep !== null;
+
+  const openTour = () => setTourStep(0);
+  const closeTour = () => setTourStep(null);
+  const handleTourNext = () =>
+    setTourStep((prev) => {
+      if (prev === null) return prev;
+      if (prev >= tourSteps.length - 1) return null;
+      return prev + 1;
+    });
+  const handleTourPrevious = () =>
+    setTourStep((prev) => {
+      if (prev === null || prev <= 0) return prev;
+      return prev - 1;
+    });
 
   const generate = () => {
     if (territorios.length === 0 || saidas.length === 0) {
@@ -137,35 +198,89 @@ const SuggestionsPage: React.FC = () => {
       <Card
         title={t('suggestions.cards.rules')}
         actions={
-          <Button onClick={saveRuleDefaults} className="bg-neutral-100">
-            {t('suggestions.actions.saveDefaults')}
-          </Button>
+          <>
+            <Button onClick={openTour} className="bg-blue-600 text-white">
+              {t('suggestions.actions.viewTour')}
+            </Button>
+            <Button onClick={saveRuleDefaults} className="bg-neutral-100">
+              {t('suggestions.actions.saveDefaults')}
+            </Button>
+          </>
         }
       >
         <div className="grid md:grid-cols-6 gap-3">
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.startDate')}>{t('suggestions.labels.startDate')}</Label>
-            <Input type="date" value={startDate} onChange={(event) => setStartDate(event.target.value)} />
+          <div ref={startDateRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-startDate" title={t('suggestions.tooltips.startDate')}>
+              {t('suggestions.labels.startDate')}
+            </Label>
+            <Input
+              id="suggestion-rule-startDate"
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+            />
           </div>
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.duration')}>{t('suggestions.labels.duration')}</Label>
-            <Input type="number" min={1} value={duration} onChange={(event) => setDuration(Number(event.target.value) || 1)} />
+          <div ref={durationRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-duration" title={t('suggestions.tooltips.duration')}>
+              {t('suggestions.labels.duration')}
+            </Label>
+            <Input
+              id="suggestion-rule-duration"
+              type="number"
+              min={1}
+              value={duration}
+              onChange={(event) => setDuration(Number(event.target.value) || 1)}
+            />
           </div>
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.avoidCount')}>{t('suggestions.labels.avoidCount')}</Label>
-            <Input type="number" min={0} value={avoidCount} onChange={(event) => setAvoidCount(Number(event.target.value) || 0)} />
+          <div ref={avoidCountRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-avoidCount" title={t('suggestions.tooltips.avoidCount')}>
+              {t('suggestions.labels.avoidCount')}
+            </Label>
+            <Input
+              id="suggestion-rule-avoidCount"
+              type="number"
+              min={0}
+              value={avoidCount}
+              onChange={(event) => setAvoidCount(Number(event.target.value) || 0)}
+            />
           </div>
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.monthsPerExit')}>{t('suggestions.labels.monthsPerExit')}</Label>
-            <Input type="number" min={0} value={monthsPerExit} onChange={(event) => setMonthsPerExit(Number(event.target.value) || 0)} />
+          <div ref={monthsPerExitRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-monthsPerExit" title={t('suggestions.tooltips.monthsPerExit')}>
+              {t('suggestions.labels.monthsPerExit')}
+            </Label>
+            <Input
+              id="suggestion-rule-monthsPerExit"
+              type="number"
+              min={0}
+              value={monthsPerExit}
+              onChange={(event) => setMonthsPerExit(Number(event.target.value) || 0)}
+            />
           </div>
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.recentWeight')}>{t('suggestions.labels.recentWeight')}</Label>
-            <Input type="number" min={0} step="0.1" value={recentWeight} onChange={(event) => setRecentWeight(Number(event.target.value) || 0)} />
+          <div ref={recentWeightRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-recentWeight" title={t('suggestions.tooltips.recentWeight')}>
+              {t('suggestions.labels.recentWeight')}
+            </Label>
+            <Input
+              id="suggestion-rule-recentWeight"
+              type="number"
+              min={0}
+              step="0.1"
+              value={recentWeight}
+              onChange={(event) => setRecentWeight(Number(event.target.value) || 0)}
+            />
           </div>
-          <div className="grid gap-1">
-            <Label title={t('suggestions.tooltips.balanceWeight')}>{t('suggestions.labels.balanceWeight')}</Label>
-            <Input type="number" min={0} step="0.1" value={balanceWeight} onChange={(event) => setBalanceWeight(Number(event.target.value) || 0)} />
+          <div ref={balanceWeightRef} className="grid gap-1">
+            <Label htmlFor="suggestion-rule-balanceWeight" title={t('suggestions.tooltips.balanceWeight')}>
+              {t('suggestions.labels.balanceWeight')}
+            </Label>
+            <Input
+              id="suggestion-rule-balanceWeight"
+              type="number"
+              min={0}
+              step="0.1"
+              value={balanceWeight}
+              onChange={(event) => setBalanceWeight(Number(event.target.value) || 0)}
+            />
           </div>
           <div className="flex items-end">
             <Button onClick={generate} className="bg-black text-white w-full">
@@ -174,6 +289,15 @@ const SuggestionsPage: React.FC = () => {
           </div>
         </div>
       </Card>
+
+      <GuidedTour
+        steps={tourSteps}
+        open={isTourOpen}
+        stepIndex={tourStep ?? 0}
+        onClose={closeTour}
+        onNext={handleTourNext}
+        onPrevious={handleTourPrevious}
+      />
 
       <Card
         title={t('suggestions.cards.generated')}


### PR DESCRIPTION
## Summary
- add a reusable guided tour overlay component
- integrate the tour with suggestion rule controls and start button
- update translations with tour labels in all supported locales

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cd63ba50a483258afce42d7c4ed490