### PR TITLE
Fix scheduler datetime input timezone handling

### DIFF
--- a/src/components/calendar/SchedulerControls.tsx
+++ b/src/components/calendar/SchedulerControls.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useTranslation } from 'react-i18next';
 import { useMonthlyExportScheduler } from '../../hooks/useMonthlyExportScheduler';
 import { useAuth } from '../../hooks/useAuth';
+import { formatLocalDateTimeForInput } from '../../utils/calendar';
 
 /**
  * A component for controlling the monthly export scheduler.
@@ -12,7 +13,7 @@ export const SchedulerControls: React.FC = () => {
   const { currentUser } = useAuth();
   const { config, setConfig } = useMonthlyExportScheduler(currentUser?.id);
   const { t } = useTranslation();
-  const dateValue = new Date(config.nextRun).toISOString().slice(0, 16);
+  const dateValue = formatLocalDateTimeForInput(new Date(config.nextRun));
 
   return (
     <div className="border rounded-xl p-4 mt-4">

--- a/src/utils/calendar.test.ts
+++ b/src/utils/calendar.test.ts
@@ -1,0 +1,22 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { formatLocalDateTimeForInput } from './calendar';
+
+describe('calendar utils', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('formatLocalDateTimeForInput adjusts positive timezone offsets', () => {
+    const date = new Date('2024-05-01T12:34:56Z');
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180);
+
+    expect(formatLocalDateTimeForInput(date)).toBe('2024-05-01T09:34');
+  });
+
+  test('formatLocalDateTimeForInput adjusts negative timezone offsets', () => {
+    const date = new Date('2024-05-01T00:15:00Z');
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-120);
+
+    expect(formatLocalDateTimeForInput(date)).toBe('2024-05-01T02:15');
+  });
+});

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -25,3 +25,8 @@ export const nextDateForWeekday = (baseIso: string, weekday: number): string => 
   }
   return date.toISOString().slice(0, 10);
 };
+
+export const formatLocalDateTimeForInput = (date: Date): string => {
+  const timezoneOffsetInMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - timezoneOffsetInMs).toISOString().slice(0, 16);
+};


### PR DESCRIPTION
## Summary
- add `formatLocalDateTimeForInput` helper to normalize datetimes for HTML inputs
- use the new helper in `SchedulerControls` to keep scheduler values in local time
- cover timezone conversion logic with dedicated unit tests

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd6d8988988325840cd76785587af4