### PR TITLE
Adjust date helpers to respect local timezone

### DIFF
--- a/src/pages/AssignmentsPage.tsx
+++ b/src/pages/AssignmentsPage.tsx
@@ -9,7 +9,7 @@ import { useSaidas } from '../hooks/useSaidas';
 import { useDesignacoes } from '../hooks/useDesignacoes';
 import { useSuggestionRules } from '../hooks/useSuggestionRules';
 import type { Designacao } from '../types/designacao';
-import { addDaysToIso, formatIsoDate, nextDateForWeekday } from '../utils/calendar';
+import { addDaysToIso, formatIsoDate, nextDateForWeekday, todayLocalIso } from '../utils/calendar';
 import { findName } from '../utils/lookups';
 import { getLastAssignmentDate } from '../utils/assignments';
 
@@ -21,7 +21,7 @@ const AssignmentsPage: React.FC = () => {
   const confirm = useConfirm();
   const toast = useToast();
   const { t } = useTranslation();
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const todayIso = todayLocalIso();
   const [territorioId, setTerritorioId] = useState('');
   const [saidaId, setSaidaId] = useState('');
   const [startDate, setStartDate] = useState(todayIso);

--- a/src/pages/NaoEmCasaPage.tsx
+++ b/src/pages/NaoEmCasaPage.tsx
@@ -9,7 +9,7 @@ import type { Street } from '../types/street';
 import type { Address } from '../types/address';
 import type { PropertyType } from '../types/property-type';
 import type { NaoEmCasaRegistro } from '../types/nao-em-casa';
-import { addDaysToIso, formatIsoDate } from '../utils/calendar';
+import { addDaysToIso, formatIsoDate, todayLocalIso } from '../utils/calendar';
 
 const FOLLOW_UP_DELAY_DAYS = 120;
 
@@ -114,7 +114,7 @@ const NaoEmCasaPage: React.FC = () => {
   const { registros, addNaoEmCasa, updateNaoEmCasa } = useNaoEmCasa();
   const { t } = useTranslation();
 
-  const todayIso = useMemo(() => new Date().toISOString().slice(0, 10), []);
+  const todayIso = useMemo(() => todayLocalIso(), []);
 
   const activeDesignacoes = useMemo(
     () =>
@@ -287,7 +287,7 @@ const NaoEmCasaPage: React.FC = () => {
 
   const handleMarkCompleted = useCallback(
     async (registro: NaoEmCasaRegistro) => {
-      const completionDate = new Date().toISOString().slice(0, 10);
+      const completionDate = todayLocalIso();
       await updateNaoEmCasa(registro.id, {
         completedAt: completionDate,
         conversationConfirmed: true,

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -7,7 +7,7 @@ import { useTerritorios } from '../hooks/useTerritorios';
 import { useSaidas } from '../hooks/useSaidas';
 import { useDesignacoes } from '../hooks/useDesignacoes';
 import { useSuggestionRules } from '../hooks/useSuggestionRules';
-import { addDaysToIso, formatIsoDate, nextDateForWeekday } from '../utils/calendar';
+import { addDaysToIso, formatIsoDate, nextDateForWeekday, todayLocalIso } from '../utils/calendar';
 import { findName } from '../utils/lookups';
 import { getLastAssignmentDate } from '../utils/assignments';
 
@@ -25,7 +25,7 @@ const SuggestionsPage: React.FC = () => {
   const [rules, setRules] = useSuggestionRules();
   const toast = useToast();
   const { t } = useTranslation();
-  const [startDate, setStartDate] = useState<string>(() => new Date().toISOString().slice(0, 10));
+  const [startDate, setStartDate] = useState<string>(() => todayLocalIso());
   const [duration, setDuration] = useState<number>(rules.defaultDurationDays);
   const [avoidCount, setAvoidCount] = useState<number>(rules.avoidLastAssignments);
   const [monthsPerExit, setMonthsPerExit] = useState<number>(rules.avoidMonthsPerExit);

--- a/src/utils/calendar.test.ts
+++ b/src/utils/calendar.test.ts
@@ -1,9 +1,29 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { formatLocalDateTimeForInput } from './calendar';
+import {
+  addDaysToIso,
+  formatLocalDateForInput,
+  formatLocalDateTimeForInput,
+  todayLocalIso,
+} from './calendar';
 
 describe('calendar utils', () => {
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
+  });
+
+  test('formatLocalDateForInput adjusts positive timezone offsets', () => {
+    const date = new Date('2024-05-01T01:23:45Z');
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180);
+
+    expect(formatLocalDateForInput(date)).toBe('2024-04-30');
+  });
+
+  test('formatLocalDateForInput adjusts negative timezone offsets', () => {
+    const date = new Date('2024-05-01T22:23:45Z');
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-180);
+
+    expect(formatLocalDateForInput(date)).toBe('2024-05-02');
   });
 
   test('formatLocalDateTimeForInput adjusts positive timezone offsets', () => {
@@ -18,5 +38,20 @@ describe('calendar utils', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-120);
 
     expect(formatLocalDateTimeForInput(date)).toBe('2024-05-01T02:15');
+  });
+
+  test('addDaysToIso respects local timezone offsets', () => {
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-180);
+
+    expect(addDaysToIso('2024-05-21', 0)).toBe('2024-05-21');
+    expect(addDaysToIso('2024-05-21', 5)).toBe('2024-05-26');
+  });
+
+  test('todayLocalIso returns local date string', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2024-05-01T01:00:00Z'));
+    vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(180);
+
+    expect(todayLocalIso()).toBe('2024-04-30');
   });
 });

--- a/src/utils/calendar.ts
+++ b/src/utils/calendar.ts
@@ -1,5 +1,10 @@
 const toDate = (iso: string): Date => new Date(`${iso}T00:00:00`);
 
+const toLocalISOString = (date: Date): string => {
+  const timezoneOffsetInMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - timezoneOffsetInMs).toISOString();
+};
+
 export const weekdays = [
   'Domingo',
   'Segunda',
@@ -12,10 +17,12 @@ export const weekdays = [
 
 export const formatIsoDate = (iso: string): string => toDate(iso).toLocaleDateString();
 
+export const formatLocalDateForInput = (date: Date): string => toLocalISOString(date).slice(0, 10);
+
 export const addDaysToIso = (iso: string, days: number): string => {
   const date = toDate(iso);
   date.setDate(date.getDate() + days);
-  return date.toISOString().slice(0, 10);
+  return formatLocalDateForInput(date);
 };
 
 export const nextDateForWeekday = (baseIso: string, weekday: number): string => {
@@ -23,10 +30,9 @@ export const nextDateForWeekday = (baseIso: string, weekday: number): string => 
   while (date.getDay() !== weekday) {
     date.setDate(date.getDate() + 1);
   }
-  return date.toISOString().slice(0, 10);
+  return formatLocalDateForInput(date);
 };
 
-export const formatLocalDateTimeForInput = (date: Date): string => {
-  const timezoneOffsetInMs = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - timezoneOffsetInMs).toISOString().slice(0, 16);
-};
+export const formatLocalDateTimeForInput = (date: Date): string => toLocalISOString(date).slice(0, 16);
+
+export const todayLocalIso = (): string => formatLocalDateForInput(new Date());


### PR DESCRIPTION
## Summary
- add timezone-aware helpers in `calendar.ts` to produce local ISO strings and reuse them within existing date utilities
- switch assignment-related pages to use the new helper so default dates and completion timestamps reflect the viewer's locale
- extend calendar utility tests to cover the new helpers and deterministic timezone handling

## Testing
- npm run test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd6ec3c66883258560227d3cd4ea2c