### PR TITLE
Add registration flow for unauthenticated users

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import CalendarPage from './pages/CalendarPage';
 import SuggestionsPage from './pages/SuggestionsPage';
 import NaoEmCasaPage from './pages/NaoEmCasaPage';
 import UsersPage from './pages/UsersPage';
+import RegisterPage from './pages/RegisterPage';
 import { AppProvider } from './store/AppProvider';
 import { useApp } from './hooks/useApp';
 import { useAuth } from './hooks/useAuth';
@@ -33,11 +34,12 @@ import {
 } from './services/repositories';
 import { BuildingVillageRepository } from './services/repositories/buildings_villages';
 import type { TabKey } from './types/navigation';
-import { routeEntries } from './routes';
+import { authRoutes, routeEntries } from './routes';
 import UnauthorizedPage from './pages/UnauthorizedPage';
 import { ADMIN_MASTER_ROLE } from './constants/roles';
 
 const UNAUTHORIZED_ROUTE = '/unauthorized';
+const REGISTER_ROUTE = authRoutes.register;
 const ADMIN_MASTER_ROLE_NORMALIZED = ADMIN_MASTER_ROLE.toLowerCase();
 
 const pagesByTab: Record<TabKey, ComponentType> = {
@@ -69,7 +71,7 @@ export const RouteGuard = ({ component: Component, allowedRoles, currentRole, pa
   if (normalizedRole === null) {
     return (
       <Navigate
-        to={UNAUTHORIZED_ROUTE}
+        to={REGISTER_ROUTE}
         replace
         state={{ from: path, reason: 'unauthenticated' }}
       />
@@ -204,6 +206,7 @@ export const AppContent = () => {
   return (
     <Shell>
       <Routes>
+        <Route path={REGISTER_ROUTE} element={<RegisterPage />} />
         {routeEntries.map(([key, config]) => {
           const PageComponent = pagesByTab[key];
           return (

--- a/src/AppRouteGuard.test.tsx
+++ b/src/AppRouteGuard.test.tsx
@@ -4,11 +4,12 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 import { cleanup, render, screen, waitFor } from '@testing-library/react';
 
 import { RouteGuard } from './App';
-import { routes } from './routes';
+import { authRoutes, routes } from './routes';
 import { ADMIN_MASTER_ROLE } from './constants/roles';
 
 describe('RouteGuard', () => {
   const fallbackLabel = 'Acesso negado';
+  const registerLabel = 'Registro';
   const ManagementComponent = () => <div>Gestão</div>;
   const LettersComponent = () => <div>Cartas</div>;
   const UsersComponent = () => <div>Usuários</div>;
@@ -46,10 +47,26 @@ describe('RouteGuard', () => {
             }
           />
           <Route path="/unauthorized" element={<div>{fallbackLabel}</div>} />
+          <Route path={authRoutes.register} element={<div>{registerLabel}</div>} />
         </Routes>
       </BrowserRouter>
     );
   };
+
+  it('redirects unauthenticated visitors to the registration route', async () => {
+    expect(RouteGuard).toBeDefined();
+
+    renderGuard({
+      component: ManagementComponent,
+      allowedRoles: routes.territories.allowedRoles,
+      currentRole: null,
+      path: routes.territories.path,
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(registerLabel)).toBeDefined();
+    });
+  });
 
   it('redirects management-only routes when the user role is not permitted', async () => {
     expect(RouteGuard).toBeDefined();

--- a/src/components/auth/AuthControls.tsx
+++ b/src/components/auth/AuthControls.tsx
@@ -1,8 +1,10 @@
 import { FormEvent, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { useAuth } from '../../hooks/useAuth';
 import { Button, Input, Label } from '../ui';
 import { useToast } from '../feedback/Toast';
+import { authRoutes } from '../../routes';
 
 interface AuthControlsProps {
   className?: string;
@@ -88,13 +90,21 @@ export const AuthControls = ({ className = '' }: AuthControlsProps) => {
           className="w-28"
         />
       </div>
-      <Button
-        type="submit"
-        className="bg-emerald-500 text-white hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
-        disabled={!canSubmit}
-      >
-        {t('auth.signIn')}
-      </Button>
+      <div className="flex items-center gap-3">
+        <Button
+          type="submit"
+          className="bg-emerald-500 text-white hover:bg-emerald-600 disabled:opacity-50 disabled:cursor-not-allowed"
+          disabled={!canSubmit}
+        >
+          {t('auth.signIn')}
+        </Button>
+        <Link
+          to={authRoutes.register}
+          className="text-sm text-emerald-600 hover:underline"
+        >
+          {t('register.cta')}
+        </Link>
+      </div>
     </form>
   );
 };

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -453,6 +453,29 @@
     "signOut": "Sign out",
     "invalidCredentials": "Invalid credentials. Please check your details and try again."
   },
+  "register": {
+    "title": "Create your account",
+    "subtitle": "Fill in the information below to create a new account.",
+    "cta": "Create account",
+    "submit": "Create account",
+    "submitting": "Creating...",
+    "alreadyHaveAccount": "Already have an account?",
+    "signInHint": "Use the sign-in form in the header.",
+    "redirectMessage": "Create an account or sign in to access {{from}}.",
+    "success": "Account created successfully! You are now signed in.",
+    "fields": {
+      "name": "Name",
+      "email": "Email",
+      "password": "Password"
+    },
+    "errors": {
+      "nameRequired": "Enter your name",
+      "emailInvalid": "Enter a valid email address",
+      "emailTaken": "This email is already associated with an account",
+      "passwordLength": "Use at least {{min}} characters",
+      "generic": "We couldn't create your account. Please try again."
+    }
+  },
   "language": {
     "english": "English",
     "portuguese": "Portuguese",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -455,6 +455,29 @@
     "signOut": "Sair",
     "invalidCredentials": "Credenciais inválidas. Verifique os dados e tente novamente."
   },
+  "register": {
+    "title": "Crie sua conta",
+    "subtitle": "Preencha os dados abaixo para criar uma nova conta.",
+    "cta": "Criar conta",
+    "submit": "Criar conta",
+    "submitting": "Criando...",
+    "alreadyHaveAccount": "Já possui uma conta?",
+    "signInHint": "Use o formulário de acesso no topo da página.",
+    "redirectMessage": "Crie uma conta ou faça login para acessar {{from}}.",
+    "success": "Conta criada com sucesso! Você já está autenticado.",
+    "fields": {
+      "name": "Nome",
+      "email": "E-mail",
+      "password": "Senha"
+    },
+    "errors": {
+      "nameRequired": "Informe seu nome",
+      "emailInvalid": "Informe um e-mail válido",
+      "emailTaken": "Este e-mail já está associado a uma conta",
+      "passwordLength": "Utilize pelo menos {{min}} caracteres",
+      "generic": "Não foi possível criar sua conta. Tente novamente."
+    }
+  },
   "language": {
     "english": "Inglês",
     "portuguese": "Português",

--- a/src/pages/RegisterPage.tsx
+++ b/src/pages/RegisterPage.tsx
@@ -1,0 +1,242 @@
+import { FormEvent, useEffect, useMemo, useState } from 'react';
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useTranslation } from 'react-i18next';
+import { Button, Card, Input, Label } from '../components/ui';
+import { useToast } from '../components/feedback/Toast';
+import { useApp } from '../hooks/useApp';
+import { generateId } from '../utils/id';
+import { hashPassword } from '../utils/password';
+import { UserRepository } from '../services/repositories';
+import type { User } from '../types/user';
+import type { AuthUser } from '../store/appReducer';
+import { routeEntries } from '../routes';
+import { useAuth } from '../hooks/useAuth';
+
+interface RegisterRedirectState {
+  from?: string;
+  reason?: 'unauthenticated' | 'unauthorized';
+}
+
+interface RegisterFormState {
+  name: string;
+  email: string;
+  password: string;
+}
+
+interface RegisterFormErrors {
+  name?: string;
+  email?: string;
+  password?: string;
+  general?: string;
+}
+
+const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const findFirstAccessibleRoute = (role: string | null): string | null => {
+  const normalizedRole = role?.trim().toLowerCase() ?? '';
+  if (!normalizedRole) {
+    return null;
+  }
+
+  for (const [, config] of routeEntries) {
+    if (config.allowedRoles.some((allowed) => allowed.toLowerCase() === normalizedRole)) {
+      return config.path;
+    }
+  }
+
+  return null;
+};
+
+const INITIAL_FORM_STATE: RegisterFormState = {
+  name: '',
+  email: '',
+  password: '',
+};
+
+const RegisterPage = () => {
+  const { t } = useTranslation();
+  const { dispatch } = useApp();
+  const toast = useToast();
+  const { currentUser } = useAuth();
+  const location = useLocation();
+  const navigate = useNavigate();
+  const redirectState = (location.state as RegisterRedirectState | undefined) ?? undefined;
+  const [form, setForm] = useState<RegisterFormState>(INITIAL_FORM_STATE);
+  const [errors, setErrors] = useState<RegisterFormErrors>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (!currentUser) {
+      return;
+    }
+
+    const target = findFirstAccessibleRoute(currentUser.role);
+    if (target) {
+      navigate(target, { replace: true });
+    }
+  }, [currentUser, navigate]);
+
+  const registrationHint = useMemo(() => {
+    if (!redirectState?.from) {
+      return null;
+    }
+
+    return t('register.redirectMessage', { from: redirectState.from });
+  }, [redirectState?.from, t]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (isSubmitting) {
+      return;
+    }
+
+    setErrors({});
+
+    const trimmedName = form.name.trim();
+    const trimmedEmail = form.email.trim();
+    const trimmedPassword = form.password.trim();
+
+    const nextErrors: RegisterFormErrors = {};
+
+    if (!trimmedName) {
+      nextErrors.name = t('register.errors.nameRequired');
+    }
+
+    if (!emailPattern.test(trimmedEmail)) {
+      nextErrors.email = t('register.errors.emailInvalid');
+    }
+
+    if (trimmedPassword.length < 6) {
+      nextErrors.password = t('register.errors.passwordLength', { min: 6 });
+    }
+
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const normalizedEmail = trimmedEmail.toLowerCase();
+      const existing = await UserRepository.findByEmail(normalizedEmail);
+      if (existing) {
+        setErrors({ email: t('register.errors.emailTaken') });
+        return;
+      }
+
+      const passwordHash = await hashPassword(trimmedPassword);
+      const now = new Date().toISOString();
+      const record: User = {
+        id: generateId(),
+        name: trimmedName,
+        email: normalizedEmail,
+        role: 'viewer',
+        passwordHash,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      await UserRepository.add(record);
+      dispatch({ type: 'ADD_USER', payload: record });
+
+      const authPayload: AuthUser = {
+        id: record.id,
+        role: record.role,
+        createdAt: now,
+        updatedAt: now,
+      };
+
+      dispatch({ type: 'SIGN_IN', payload: authPayload });
+      toast.success(t('register.success'));
+      setErrors({});
+      setForm(INITIAL_FORM_STATE);
+    } catch (error) {
+      console.error('Failed to register user', error);
+      setErrors({ general: t('register.errors.generic') });
+      toast.error(t('register.errors.generic'));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const canSubmit =
+    form.name.trim().length > 0 &&
+    emailPattern.test(form.email.trim()) &&
+    form.password.trim().length >= 6 &&
+    !isSubmitting;
+
+  return (
+    <section className="mx-auto flex w-full max-w-xl flex-col gap-6 py-10">
+      <Card title={t('register.title')}>
+        <form className="space-y-4" onSubmit={handleSubmit} noValidate>
+          <p className="text-sm text-neutral-600 dark:text-neutral-300">
+            {t('register.subtitle')}
+          </p>
+          {registrationHint ? (
+            <p className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-200">
+              {registrationHint}
+            </p>
+          ) : null}
+          <div className="space-y-1">
+            <Label htmlFor="register-name">{t('register.fields.name')}</Label>
+            <Input
+              id="register-name"
+              value={form.name}
+              onChange={(event) => setForm((prev) => ({ ...prev, name: event.target.value }))}
+              autoComplete="name"
+              required
+              disabled={isSubmitting}
+            />
+            {errors.name ? <p className="text-sm text-red-600">{errors.name}</p> : null}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="register-email">{t('register.fields.email')}</Label>
+            <Input
+              id="register-email"
+              type="email"
+              value={form.email}
+              onChange={(event) => setForm((prev) => ({ ...prev, email: event.target.value }))}
+              autoComplete="email"
+              inputMode="email"
+              required
+              disabled={isSubmitting}
+            />
+            {errors.email ? <p className="text-sm text-red-600">{errors.email}</p> : null}
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="register-password">{t('register.fields.password')}</Label>
+            <Input
+              id="register-password"
+              type="password"
+              value={form.password}
+              onChange={(event) => setForm((prev) => ({ ...prev, password: event.target.value }))}
+              autoComplete="new-password"
+              minLength={6}
+              required
+              disabled={isSubmitting}
+            />
+            {errors.password ? <p className="text-sm text-red-600">{errors.password}</p> : null}
+          </div>
+          {errors.general ? <p className="text-sm text-red-600">{errors.general}</p> : null}
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              type="submit"
+              disabled={!canSubmit}
+              className="bg-emerald-500 text-white hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {isSubmitting ? t('register.submitting') : t('register.submit')}
+            </Button>
+            <span className="text-sm text-neutral-600 dark:text-neutral-300">
+              {t('register.alreadyHaveAccount')}{' '}
+              {t('register.signInHint')}
+            </span>
+          </div>
+        </form>
+      </Card>
+    </section>
+  );
+};
+
+export default RegisterPage;
+

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -6,6 +6,10 @@ export interface RouteDefinition {
   allowedRoles: ReadonlyArray<string>;
 }
 
+export const authRoutes = {
+  register: '/register',
+} as const;
+
 const managementRoles = [ADMIN_MASTER_ROLE, 'admin', 'manager'] as const;
 const adminMasterOnlyRoles = [ADMIN_MASTER_ROLE] as const;
 const publisherRoles = [...managementRoles, 'publisher'] as const;


### PR DESCRIPTION
## Summary
- add a RegisterPage that validates user details, hashes passwords, persists the new user record and signs the user in
- expose a public /register route, redirect unauthenticated RouteGuard traffic there and link to it from the AuthControls header
- localize registration copy in both supported languages

## Testing
- npm run test -- --run (fails: src/utils/calendar.test.ts unexpected EOF and existing Dexie setup error)
- npm run test -- --run src/AppRouteGuard.test.tsx


------
https://chatgpt.com/codex/tasks/task_e_68cd89e0c1b483259caee8197fd9313d