### PR TITLE
Add viewer today assignments page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import CalendarPage from './pages/CalendarPage';
 import SuggestionsPage from './pages/SuggestionsPage';
 import NaoEmCasaPage from './pages/NaoEmCasaPage';
 import UsersPage from './pages/UsersPage';
+import TodayAssignmentsPage from './pages/TodayAssignmentsPage';
 import RegisterPage from './pages/RegisterPage';
 import { AppProvider } from './store/AppProvider';
 import { useApp } from './hooks/useApp';
@@ -50,6 +51,7 @@ const pagesByTab: Record<TabKey, ComponentType> = {
   exits: ExitsPage,
   assignments: AssignmentsPage,
   users: UsersPage,
+  todayAssignments: TodayAssignmentsPage,
   calendar: CalendarPage,
   suggestions: SuggestionsPage,
   notAtHome: NaoEmCasaPage,

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -30,6 +30,20 @@ const AssignIcon = () => (
   </svg>
 );
 
+const TodayIcon = () => (
+  <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
+    <circle cx="12" cy="12" r="4" />
+    <path d="M12 2v2" />
+    <path d="M12 20v2" />
+    <path d="M4.93 4.93l1.41 1.41" />
+    <path d="M17.66 17.66l1.41 1.41" />
+    <path d="M2 12h2" />
+    <path d="M20 12h2" />
+    <path d="M6.34 17.66l-1.41 1.41" />
+    <path d="M19.07 4.93l-1.41 1.41" />
+  </svg>
+);
+
 const CalendarIcon = () => (
   <svg viewBox="0 0 24 24" className={iconCls} fill="none" stroke="currentColor" strokeWidth="2">
     <rect x="3" y="4" width="18" height="18" rx="2" />
@@ -91,6 +105,7 @@ const items: Array<{ id: TabKey; label: string; icon: React.ReactNode }> = [
   { id: 'exits', label: 'sidebar.exits', icon: <ExitIcon /> },
   { id: 'assignments', label: 'sidebar.assignments', icon: <AssignIcon /> },
   { id: 'users', label: 'sidebar.users', icon: <UsersIcon /> },
+  { id: 'todayAssignments', label: 'sidebar.todayAssignments', icon: <TodayIcon /> },
   { id: 'calendar', label: 'sidebar.calendar', icon: <CalendarIcon /> },
   { id: 'notAtHome', label: 'sidebar.notAtHome', icon: <HomeOffIcon /> },
   { id: 'suggestions', label: 'sidebar.suggestions', icon: <SuggestIcon /> },

--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -46,6 +46,7 @@
     "letters": "Letters",
     "exits": "Exits",
     "assignments": "Assignments",
+    "todayAssignments": "Today's assignments",
     "calendar": "Calendar",
     "suggestions": "Suggestions",
     "notAtHome": "Not at Home",
@@ -87,6 +88,16 @@
     "unknownStreet": "Unknown street",
     "unknownType": "Unknown type",
     "addressLabel": "{{street}} • no. {{range}}"
+  },
+
+  "viewerAssignments": {
+    "title": "Today's assignments",
+    "currentDate": "Reference date: {{date}}",
+    "empty": "No territories assigned for today.",
+    "summary": "Active territories today: {{count}}",
+    "assignmentRange": "Period: {{start}} – {{end}}",
+    "exitLabel": "Group: {{name}}",
+    "returnBy": "Return by {{date}}"
   },
 
   "buildingsVillages": {

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -46,6 +46,7 @@
     "letters": "Correspondencia",
     "exits": "Salidas",
     "assignments": "Asignaciones",
+    "todayAssignments": "Asignaciones de hoy",
     "calendar": "Calendario",
     "suggestions": "Sugerencias",
     "notAtHome": "No en Casa",
@@ -87,6 +88,15 @@
     "unknownStreet": "Calle desconocida",
     "unknownType": "Tipo desconocido",
     "addressLabel": "{{street}} • n.º {{range}}"
+  },
+  "viewerAssignments": {
+    "title": "Asignaciones de hoy",
+    "currentDate": "Fecha de referencia: {{date}}",
+    "empty": "No hay territorios asignados para hoy.",
+    "summary": "Territorios activos hoy: {{count}}",
+    "assignmentRange": "Periodo: {{start}} – {{end}}",
+    "exitLabel": "Salida: {{name}}",
+    "returnBy": "Devolver antes del {{date}}"
   },
   "buildingsVillages": {
     "title": "Edificios y Villas",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -46,6 +46,7 @@
     "letters": "Cartas",
     "exits": "Saídas",
     "assignments": "Designações",
+    "todayAssignments": "Designações do dia",
     "calendar": "Calendário",
     "suggestions": "Sugestões",
     "notAtHome": "Não em Casa",
@@ -87,6 +88,16 @@
     "unknownStreet": "Rua não informada",
     "unknownType": "Tipo não informado",
     "addressLabel": "{{street}} • nº {{range}}"
+  },
+
+  "viewerAssignments": {
+    "title": "Designações do dia",
+    "currentDate": "Data de referência: {{date}}",
+    "empty": "Nenhum território designado para hoje.",
+    "summary": "Total de territórios ativos hoje: {{count}}",
+    "assignmentRange": "Período: {{start}} – {{end}}",
+    "exitLabel": "Saída: {{name}}",
+    "returnBy": "Devolver até {{date}}"
   },
 
   "buildingsVillages": {

--- a/src/pages/TodayAssignmentsPage.tsx
+++ b/src/pages/TodayAssignmentsPage.tsx
@@ -1,0 +1,85 @@
+import React, { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card } from '../components/ui';
+import { useDesignacoes } from '../hooks/useDesignacoes';
+import { useTerritorios } from '../hooks/useTerritorios';
+import { useSaidas } from '../hooks/useSaidas';
+import { formatIsoDate, todayLocalIso } from '../utils/calendar';
+import { findName } from '../utils/lookups';
+
+const TodayAssignmentsPage: React.FC = () => {
+  const { t } = useTranslation();
+  const { designacoes } = useDesignacoes();
+  const { territorios } = useTerritorios();
+  const { saidas } = useSaidas();
+
+  const todayIso = useMemo(() => todayLocalIso(), []);
+
+  const todaysAssignments = useMemo(() => {
+    return designacoes
+      .filter(
+        (designacao) =>
+          designacao.dataInicial <= todayIso &&
+          designacao.dataFinal >= todayIso &&
+          !designacao.devolvido,
+      )
+      .map((designacao) => ({
+        designacao,
+        territoryName: findName(designacao.territorioId, territorios),
+        exitName: findName(designacao.saidaId, saidas),
+      }))
+      .sort((a, b) => a.territoryName.localeCompare(b.territoryName, undefined, { sensitivity: 'base' }));
+  }, [designacoes, saidas, territorios, todayIso]);
+
+  return (
+    <div className="grid gap-4">
+      <Card title={t('viewerAssignments.title')}>
+        <div className="grid gap-4">
+          <p className="text-sm text-neutral-600 dark:text-neutral-300">
+            {t('viewerAssignments.currentDate', { date: formatIsoDate(todayIso) })}
+          </p>
+
+          {todaysAssignments.length === 0 ? (
+            <p className="text-sm text-neutral-500 dark:text-neutral-400">
+              {t('viewerAssignments.empty')}
+            </p>
+          ) : (
+            <div className="grid gap-3">
+              <p className="text-sm text-neutral-600 dark:text-neutral-300">
+                {t('viewerAssignments.summary', { count: todaysAssignments.length })}
+              </p>
+              <ul className="grid gap-3">
+                {todaysAssignments.map(({ designacao, territoryName, exitName }) => (
+                  <li
+                    key={designacao.id}
+                    className="rounded-xl border border-neutral-200 dark:border-neutral-700 bg-white dark:bg-neutral-900 px-4 py-3 shadow-sm"
+                  >
+                    <div className="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+                      <div className="grid gap-1">
+                        <span className="font-medium text-neutral-900 dark:text-neutral-100">{territoryName}</span>
+                        <span className="text-sm text-neutral-600 dark:text-neutral-300">
+                          {t('viewerAssignments.assignmentRange', {
+                            start: formatIsoDate(designacao.dataInicial),
+                            end: formatIsoDate(designacao.dataFinal),
+                          })}
+                        </span>
+                      </div>
+                      <div className="grid gap-1 text-sm text-neutral-600 dark:text-neutral-300 text-left sm:text-right">
+                        {exitName !== '—' && (
+                          <span>{t('viewerAssignments.exitLabel', { name: exitName })}</span>
+                        )}
+                        <span>{t('viewerAssignments.returnBy', { date: formatIsoDate(designacao.dataFinal) })}</span>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+        </div>
+      </Card>
+    </div>
+  );
+};
+
+export default TodayAssignmentsPage;

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -23,6 +23,7 @@ export const routes: Record<TabKey, RouteDefinition> = {
   exits: { path: '/exits', allowedRoles: managementRoles },
   assignments: { path: '/assignments', allowedRoles: managementRoles },
   users: { path: '/users', allowedRoles: adminMasterOnlyRoles },
+  todayAssignments: { path: '/today', allowedRoles: readOnlyRoles },
   calendar: { path: '/calendar', allowedRoles: readOnlyRoles },
   suggestions: { path: '/suggestions', allowedRoles: managementRoles },
   notAtHome: { path: '/nao-em-casa', allowedRoles: publisherRoles }

--- a/src/types/navigation.ts
+++ b/src/types/navigation.ts
@@ -6,6 +6,7 @@ export type TabKey =
   | 'exits'
   | 'assignments'
   | 'users'
+  | 'todayAssignments'
   | 'calendar'
   | 'suggestions'
   | 'notAtHome';

--- a/src/utils/calendar.test.ts
+++ b/src/utils/calendar.test.ts
@@ -1,5 +1,4 @@
 import { afterEach, describe, expect, test, vi } from 'vitest';
-import { formatLocalDateForInput, formatLocalDateTimeForInput, todayLocalIso } from './calendar';
 import {
   addDaysToIso,
   formatLocalDateForInput,
@@ -9,7 +8,6 @@ import {
 
 describe('calendar utils', () => {
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     vi.useRealTimers();
   });
@@ -56,7 +54,6 @@ describe('calendar utils', () => {
     expect(formatLocalDateForInput(date)).toBe('2024-05-02');
   });
 
-  test('todayLocalIso returns the local ISO date for the current day', () => {
   test('addDaysToIso respects local timezone offsets', () => {
     vi.spyOn(Date.prototype, 'getTimezoneOffset').mockReturnValue(-180);
 


### PR DESCRIPTION
## Summary
- add a viewer-focused today assignments page that lists active territories using existing designation data hooks
- expose the new route and sidebar entry to read-only roles while keeping management features restricted
- translate the new labels and clean up the calendar tests so linting succeeds

## Testing
- npm run lint
- npm test *(fails: Dexie db.addresses undefined during streetsPublisherScoping.test.tsx setup)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8df67270832599fae68388659026