### PR TITLE
Simplify address number capture to single field

### DIFF
--- a/src/locales/en-US/translation.json
+++ b/src/locales/en-US/translation.json
@@ -227,13 +227,11 @@
     "addressesForm": {
       "selectStreet": "Select a street",
       "selectType": "Type",
-      "numberStart": "Start",
-      "numberEnd": "End"
+      "number": "Number"
     },
     "addressesTable": {
       "street": "Street",
-      "start": "Start",
-      "end": "End",
+      "number": "Number",
       "type": "Type",
       "lastVisit": "Last successful visit",
       "nextVisit": "Next visit allowed",

--- a/src/locales/es-ES/translation.json
+++ b/src/locales/es-ES/translation.json
@@ -224,13 +224,11 @@
     "addressesForm": {
       "selectStreet": "Selecciona una calle",
       "selectType": "Tipo",
-      "numberStart": "Inicio",
-      "numberEnd": "Fin"
+      "number": "Número"
     },
     "addressesTable": {
       "street": "Calle",
-      "start": "Inicio",
-      "end": "Fin",
+      "number": "Número",
       "type": "Tipo",
       "lastVisit": "Última visita exitosa",
       "nextVisit": "Próxima visita permitida",

--- a/src/locales/pt-BR/translation.json
+++ b/src/locales/pt-BR/translation.json
@@ -228,13 +228,11 @@
     "addressesForm": {
       "selectStreet": "Selecione a rua",
       "selectType": "Tipo",
-      "numberStart": "Início",
-      "numberEnd": "Fim"
+      "number": "Número"
     },
     "addressesTable": {
       "street": "Rua",
-      "start": "Início",
-      "end": "Fim",
+      "number": "Número",
       "type": "Tipo",
       "lastVisit": "Última visita bem-sucedida",
       "nextVisit": "Próxima visita liberada",

--- a/src/pages/RuasNumeracoesPage.test.tsx
+++ b/src/pages/RuasNumeracoesPage.test.tsx
@@ -214,7 +214,7 @@ const baseAddresses: Address[] = [
     id: 100,
     streetId: 1,
     numberStart: 1,
-    numberEnd: 10,
+    numberEnd: 1,
     propertyTypeId: 10,
     lastSuccessfulVisit: null,
     nextVisitAllowed: null
@@ -223,7 +223,7 @@ const baseAddresses: Address[] = [
     id: 200,
     streetId: 2,
     numberStart: 100,
-    numberEnd: 200,
+    numberEnd: 100,
     propertyTypeId: 20,
     lastSuccessfulVisit: null,
     nextVisitAllowed: null
@@ -569,7 +569,6 @@ describe('RuasNumeracoesPage', () => {
     const rowText = row.textContent ?? '';
     expect(rowText).toContain('Rua Principal');
     expect(rowText).toContain('1');
-    expect(rowText).toContain('10');
     expect(rowText).toContain('Casa');
     expect(rowText).toContain('ruasNumeracoes.addressesTable.neverVisited');
     expect(rowText).toContain('ruasNumeracoes.addressesTable.cooldownNotScheduled');
@@ -593,13 +592,11 @@ describe('RuasNumeracoesPage', () => {
 
     const streetSelect = getSelectWithinLabel('ruasNumeracoes.addressesForm.selectStreet');
     const typeSelect = getSelectWithinLabel('ruasNumeracoes.addressesForm.selectType');
-    const startInput = getInputWithinLabel('ruasNumeracoes.addressesForm.numberStart');
-    const endInput = getInputWithinLabel('ruasNumeracoes.addressesForm.numberEnd');
+    const numberInput = getInputWithinLabel('ruasNumeracoes.addressesForm.number');
 
     setSelectValue(streetSelect, '1');
     setSelectValue(typeSelect, '20');
-    setInputValue(startInput, '50');
-    setInputValue(endInput, '60');
+    setInputValue(numberInput, '50');
 
     const form = streetSelect.closest('form');
     expect(form).toBeTruthy();
@@ -612,16 +609,14 @@ describe('RuasNumeracoesPage', () => {
       expect(dbMock.addresses.put).toHaveBeenCalledWith({
         streetId: 1,
         numberStart: 50,
-        numberEnd: 60,
+        numberEnd: 50,
         propertyTypeId: 20
       });
     });
 
     await waitFor(() => {
       const rows = Array.from(document.querySelectorAll('table tbody tr'));
-      const hasNewRow = rows.some(row =>
-        row.textContent?.includes('50') && row.textContent?.includes('60')
-      );
+      const hasNewRow = rows.some(row => row.textContent?.includes('50'));
       expect(hasNewRow).toBe(true);
     });
   });

--- a/src/pages/RuasNumeracoesPage.tsx
+++ b/src/pages/RuasNumeracoesPage.tsx
@@ -269,14 +269,12 @@ export default function RuasNumeracoesPage(): JSX.Element {
 
       const streetId = parseInteger(formData.get('streetId'));
       const propertyTypeId = parseInteger(formData.get('propertyTypeId'));
-      const numberStart = parseInteger(formData.get('numberStart'));
-      const numberEnd = parseInteger(formData.get('numberEnd'));
+      const numberValue = parseInteger(formData.get('number'));
 
       if (
         streetId === null ||
         propertyTypeId === null ||
-        numberStart === null ||
-        numberEnd === null
+        numberValue === null
       ) {
         return;
       }
@@ -292,14 +290,11 @@ export default function RuasNumeracoesPage(): JSX.Element {
         return;
       }
 
-      const startNumber = Math.min(numberStart, numberEnd);
-      const endNumber = Math.max(numberStart, numberEnd);
-
       try {
         await db.addresses.put({
           streetId,
-          numberStart: startNumber,
-          numberEnd: endNumber,
+          numberStart: numberValue,
+          numberEnd: numberValue,
           propertyTypeId
         });
         await refreshTerritoryData(territoryId, currentPublisherId);
@@ -368,7 +363,11 @@ export default function RuasNumeracoesPage(): JSX.Element {
     return addresses.map(address => ({
       ...address,
       streetName: streetMap.get(address.streetId) ?? '',
-      propertyTypeName: propertyTypeMap.get(address.propertyTypeId) ?? ''
+      propertyTypeName: propertyTypeMap.get(address.propertyTypeId) ?? '',
+      numberLabel:
+        address.numberStart === address.numberEnd
+          ? `${address.numberStart}`
+          : `${address.numberStart}–${address.numberEnd}`
     }));
   }, [addresses, propertyTypes, territoryStreets]);
 
@@ -513,15 +512,9 @@ export default function RuasNumeracoesPage(): JSX.Element {
               </label>
               <label className="flex flex-col gap-1 text-sm">
                 <span className="font-medium">
-                  {t('ruasNumeracoes.addressesForm.numberStart')}
+                  {t('ruasNumeracoes.addressesForm.number')}
                 </span>
-                <input name="numberStart" type="number" className="border p-1" />
-              </label>
-              <label className="flex flex-col gap-1 text-sm">
-                <span className="font-medium">
-                  {t('ruasNumeracoes.addressesForm.numberEnd')}
-                </span>
-                <input name="numberEnd" type="number" className="border p-1" />
+                <input name="number" type="number" className="border p-1" />
               </label>
               <div className="sm:col-span-2 lg:col-span-3">
                 <button type="submit" className="border px-2 py-1 w-full sm:w-auto">
@@ -530,17 +523,14 @@ export default function RuasNumeracoesPage(): JSX.Element {
               </div>
             </form>
             <div className="overflow-x-auto">
-              <table className="w-full min-w-[640px] text-sm">
+              <table className="w-full min-w-[560px] text-sm">
                 <thead>
                   <tr>
                     <th className="px-2 py-1 text-left whitespace-nowrap">
                       {t('ruasNumeracoes.addressesTable.street')}
                     </th>
                     <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.start')}
-                    </th>
-                    <th className="px-2 py-1 text-left whitespace-nowrap">
-                      {t('ruasNumeracoes.addressesTable.end')}
+                      {t('ruasNumeracoes.addressesTable.number')}
                     </th>
                     <th className="px-2 py-1 text-left whitespace-nowrap">
                       {t('ruasNumeracoes.addressesTable.type')}
@@ -564,13 +554,12 @@ export default function RuasNumeracoesPage(): JSX.Element {
                     const nextVisit =
                       formatDateTime(address.nextVisitAllowed) ??
                       t('ruasNumeracoes.addressesTable.cooldownNotScheduled');
-                    return (
-                      <tr key={address.id ?? `${address.streetId}-${index}`}>
-                        <td className="px-2 py-1">{address.streetName || '—'}</td>
-                        <td className="px-2 py-1">{address.numberStart}</td>
-                        <td className="px-2 py-1">{address.numberEnd}</td>
-                        <td className="px-2 py-1">{address.propertyTypeName || '—'}</td>
-                        <td className="px-2 py-1">{lastVisit}</td>
+                      return (
+                        <tr key={address.id ?? `${address.streetId}-${index}`}>
+                          <td className="px-2 py-1">{address.streetName || '—'}</td>
+                          <td className="px-2 py-1">{address.numberLabel}</td>
+                          <td className="px-2 py-1">{address.propertyTypeName || '—'}</td>
+                          <td className="px-2 py-1">{lastVisit}</td>
                         <td className="px-2 py-1">{nextVisit}</td>
                         <td className="px-2 py-1">
                           <button

--- a/src/pages/streetsPublisherScoping.test.tsx
+++ b/src/pages/streetsPublisherScoping.test.tsx
@@ -3,6 +3,7 @@ import { cleanup, render, screen, waitFor } from '@testing-library/react';
 
 import type { Territorio } from '../types/territorio';
 import type { Street } from '../types/street';
+import type { Address } from '../types/address';
 
 const {
   useAuthMock,
@@ -68,6 +69,15 @@ const {
         },
       })),
       put: vi.fn(),
+    },
+    addresses: {
+      where: vi.fn((_field: keyof Address) => ({
+        anyOf: (..._values: Array<Address[keyof Address]>) => ({
+          async toArray() {
+            return [] as Address[];
+          },
+        }),
+      })),
     },
   };
 


### PR DESCRIPTION
## Summary
- update RuasNumeracoesPage to accept a single address number input and show a unified number column
- align translations and tests with the single-number interface and validation rules
- extend the publisher scoping test database mock to include the addresses store

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_e_68cd916853708325b75ee65b26e24806