### PR TITLE
Improve dark mode styles for neutral buttons

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,10 +184,16 @@ const DataManagementControls: React.FC = () => {
         className="hidden"
       />
       <div className="flex flex-wrap justify-end gap-2">
-        <Button onClick={handleExport} className="mt-4 bg-neutral-100">
+        <Button
+          onClick={handleExport}
+          className="mt-4 bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+        >
           Exportar
         </Button>
-        <Button onClick={handleImportClick} className="mt-4 bg-neutral-100">
+        <Button
+          onClick={handleImportClick}
+          className="mt-4 bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+        >
           Importar
         </Button>
         <Button onClick={handleClick} className="mt-4 bg-red-600 text-white">

--- a/src/components/ui/ImagePicker.tsx
+++ b/src/components/ui/ImagePicker.tsx
@@ -43,7 +43,10 @@ export const ImagePicker: React.FC<ImagePickerProps> = ({ value, onChange, compr
       <div className="flex items-center gap-2">
         <input type="file" accept="image/*" onChange={(event) => handleFile(event.target.files?.[0])} />
         {value && (
-          <Button onClick={() => onChange(undefined)} className="bg-neutral-100 dark:bg-neutral-800">
+          <Button
+            onClick={() => onChange(undefined)}
+            className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+          >
             Remover
           </Button>
         )}

--- a/src/pages/AssignmentsPage.tsx
+++ b/src/pages/AssignmentsPage.tsx
@@ -174,7 +174,10 @@ const AssignmentsPage: React.FC = () => {
                         <StatusBadge status={status} />
                       </td>
                       <td className="text-right flex gap-2 justify-end">
-                        <Button onClick={() => toggleDesignacaoReturn(designacao)} className="bg-neutral-100">
+                        <Button
+                          onClick={() => toggleDesignacaoReturn(designacao)}
+                          className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+                        >
                           {designacao.devolvido ? t('assignments.reactivate') : t('assignments.markAsReturned')}
                         </Button>
                         <Button

--- a/src/pages/CalendarPage.tsx
+++ b/src/pages/CalendarPage.tsx
@@ -36,11 +36,17 @@ const CalendarPage: React.FC = () => {
       <Card>
         <div className="flex items-center justify-between mb-4">
           <div className="flex items-center gap-2">
-            <Button onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1))} className="bg-neutral-100">
+            <Button
+              onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() - 1, 1))}
+              className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+            >
               ◀
             </Button>
             <h2 className="font-semibold">{month.toLocaleString('default', { month: 'long', year: 'numeric' })}</h2>
-            <Button onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1))} className="bg-neutral-100">
+            <Button
+              onClick={() => setMonth(new Date(month.getFullYear(), month.getMonth() + 1, 1))}
+              className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+            >
               ▶
             </Button>
           </div>
@@ -134,7 +140,10 @@ const CalendarPage: React.FC = () => {
               );
             })()}
             <div className="text-right">
-              <Button onClick={close} className="bg-neutral-100">
+              <Button
+                onClick={close}
+                className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+              >
                 {t('app.close')}
               </Button>
             </div>

--- a/src/pages/SuggestionsPage.tsx
+++ b/src/pages/SuggestionsPage.tsx
@@ -202,7 +202,10 @@ const SuggestionsPage: React.FC = () => {
             <Button onClick={openTour} className="bg-blue-600 text-white">
               {t('suggestions.actions.viewTour')}
             </Button>
-            <Button onClick={saveRuleDefaults} className="bg-neutral-100">
+            <Button
+              onClick={saveRuleDefaults}
+              className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+            >
               {t('suggestions.actions.saveDefaults')}
             </Button>
           </>

--- a/src/pages/TerritoriesPage.tsx
+++ b/src/pages/TerritoriesPage.tsx
@@ -84,7 +84,7 @@ const TerritoriesPage: React.FC = () => {
                   reset();
                   setEditingId(null);
                 }}
-                className="bg-neutral-100"
+                className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
               >
                 {t('common.cancel')}
               </Button>
@@ -152,7 +152,10 @@ const TerritoriesPage: React.FC = () => {
                     </td>
                     <td className="py-2 text-right">
                       <div className="flex gap-2 justify-end">
-                        <Button onClick={() => startEdit(territorio)} className="bg-neutral-100">
+                        <Button
+                          onClick={() => startEdit(territorio)}
+                          className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+                        >
                           {t('common.edit')}
                         </Button>
                         <Button

--- a/src/pages/UnauthorizedPage.tsx
+++ b/src/pages/UnauthorizedPage.tsx
@@ -40,7 +40,7 @@ const UnauthorizedPage = () => {
       </div>
       <Link
         to="/"
-        className="rounded-xl px-3 py-2 border bg-neutral-100 hover:bg-neutral-200 transition"
+        className="rounded-xl px-3 py-2 border bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700 transition"
       >
         Voltar para o início
       </Link>

--- a/src/pages/UsersPage.tsx
+++ b/src/pages/UsersPage.tsx
@@ -185,7 +185,11 @@ const UsersPage: React.FC = () => {
           </div>
           <div className="flex items-end justify-end gap-2 md:col-span-6">
             {editingId && (
-              <Button type="button" className="bg-neutral-100" onClick={resetForm}>
+              <Button
+                type="button"
+                className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+                onClick={resetForm}
+              >
                 {t('users.form.cancel')}
               </Button>
             )}
@@ -218,7 +222,11 @@ const UsersPage: React.FC = () => {
                   <p className="text-sm text-neutral-500">{t(`users.roles.${user.role}`)}</p>
                 </div>
                 <div className="flex gap-2">
-                  <Button type="button" className="bg-neutral-100" onClick={() => handleEdit(user)}>
+                  <Button
+                    type="button"
+                    className="bg-neutral-100 text-neutral-900 hover:bg-neutral-200 border-neutral-200 dark:bg-neutral-800 dark:text-neutral-100 dark:hover:bg-neutral-700 dark:border-neutral-700"
+                    onClick={() => handleEdit(user)}
+                  >
                     {t('users.actions.edit')}
                   </Button>
                   <Button

--- a/src/pages/streetsPublisherScoping.test.tsx
+++ b/src/pages/streetsPublisherScoping.test.tsx
@@ -71,12 +71,16 @@ const {
       put: vi.fn(),
     },
     addresses: {
-      where: vi.fn((_field: keyof Address) => ({
-        anyOf: (..._values: Array<Address[keyof Address]>) => ({
-          async toArray() {
-            return [] as Address[];
-          },
-        }),
+      where: vi.fn((field: keyof Address) => ({
+        anyOf: (...values: Array<Address[keyof Address]>) => {
+          void field;
+          void values;
+          return {
+            async toArray() {
+              return [] as Address[];
+            },
+          };
+        },
       })),
     },
   };


### PR DESCRIPTION
## Summary
- apply dark-mode aware backgrounds, borders, text, and hover states to neutral buttons across data management, assignments, suggestions, calendar, territories, and user screens
- align the image picker remove control and unauthorized return link with the same neutral palette for readability in dark mode
- update the streets publisher mock to consume its parameters and keep lint happy

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cdacc8370c832589c00fcbfae823c8