### PR TITLE
Improve scheduler controls dark mode contrast

### DIFF
--- a/src/components/calendar/SchedulerControls.tsx
+++ b/src/components/calendar/SchedulerControls.tsx
@@ -16,7 +16,7 @@ export const SchedulerControls: React.FC = () => {
   const dateValue = formatLocalDateTimeForInput(new Date(config.nextRun));
 
   return (
-    <div className="border rounded-xl p-4 mt-4">
+    <div className="border border-neutral-200 dark:border-neutral-700 rounded-xl p-4 mt-4 bg-white dark:bg-neutral-900">
       <h2 className="text-lg font-semibold mb-2">{t('scheduler.title')}</h2>
       <label className="flex items-center gap-2">
         <input
@@ -27,7 +27,9 @@ export const SchedulerControls: React.FC = () => {
         <span>{t('scheduler.enable')}</span>
       </label>
       <div className="mt-2">
-        <span className="text-sm text-neutral-600 mr-2">{t('scheduler.nextRun')}</span>
+        <span className="text-sm text-neutral-600 dark:text-neutral-300 mr-2">
+          {t('scheduler.nextRun')}
+        </span>
         <input
           type="datetime-local"
           value={dateValue}


### PR DESCRIPTION
## Summary
- add explicit dark mode border and background colors to the scheduler controls container
- lighten the "next run" label text in dark mode to keep it legible

## Testing
- npm run lint
- manual visual inspection of scheduler controls in dark mode

------
https://chatgpt.com/codex/tasks/task_e_68cdae4435b4832597b8ec63a9a24f04